### PR TITLE
fix: read/write encoding for `open(...)` is now `utf-8`

### DIFF
--- a/horde_worker_regen/bridge_data/data_model.py
+++ b/horde_worker_regen/bridge_data/data_model.py
@@ -56,7 +56,7 @@ class reGenBridgeData(CombinedHordeBridgeData):
         if self._yaml_loader is None:
             self._yaml_loader = YAML()
 
-        with open(file_path, "w") as f:
+        with open(file_path, "w", encoding="utf-8") as f:
             self._yaml_loader.dump(self.model_dump(), f)
 
 

--- a/horde_worker_regen/bridge_data/load_config.py
+++ b/horde_worker_regen/bridge_data/load_config.py
@@ -79,7 +79,7 @@ class BridgeDataLoader:
 
         if file_format == ConfigFormat.yaml:
             yaml = YAML()
-            with open(file_path) as f:
+            with open(file_path, encoding="utf-8") as f:
                 config = yaml.load(f)
 
             bridge_data = reGenBridgeData.model_validate(config)
@@ -87,7 +87,7 @@ class BridgeDataLoader:
                 bridge_data._yaml_loader = yaml
 
         if file_format == ConfigFormat.json:
-            with open(file_path) as f:
+            with open(file_path, encoding="utf-8") as f:
                 config = json.load(f)
 
             bridge_data = reGenBridgeData.model_validate(config)

--- a/load_env_vars.py
+++ b/load_env_vars.py
@@ -13,7 +13,7 @@ def load_env_vars() -> None:
     if not pathlib.Path("bridgeData.yaml").exists():
         raise FileNotFoundError("bridgeData.yaml not found")
 
-    with open("bridgeData.yaml") as f:
+    with open("bridgeData.yaml", encoding="utf-8") as f:
         config = yaml.load(f)
 
     if "cache_home" in config:

--- a/tests/test_bridge_data.py
+++ b/tests/test_bridge_data.py
@@ -14,7 +14,7 @@ def test_bridge_data_yaml() -> None:
 
     yaml = YAML(typ="safe")
 
-    with open(bridge_data_filename) as f:
+    with open(bridge_data_filename, encoding="utf-8") as f:
         bridge_data_raw = yaml.load(f)
 
     assert bridge_data_raw is not None


### PR DESCRIPTION
This should fix the problem where worker names with extended characters were being mangled. I also suspect there would/could be other issues in a general sense without this change.