### PR TITLE
Replace processes when a model is unloaded

### DIFF
--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -2235,6 +2235,6 @@ class HordeWorkerProcessManager:
         """
         now = datetime.datetime.now()
         for process_info in self._process_map.values():
-            if (now - process_info.last_timestamp) > self.process_timeout:
+            if (now - process_info.last_timestamp) > self.process_timeout and process_info.is_process_busy():
                 logger.error(f"{process_info} has exceeded its timeout and will be replaced")
                 self._replace_inference_process(process_info)

--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -1190,17 +1190,16 @@ class HordeWorkerProcessManager:
             if model_is_loaded:
                 continue
 
-            available_process = None
+            available_process = self._process_map.get_first_available_inference_process()
             model_to_unload = self._lru.append(job.model)
-            if model_to_unload is not None:
+
+            if available_process is None and model_to_unload is not None:
                 for p in self._process_map.values():
                     if p.loaded_horde_model_name == model_to_unload and (
                         p.last_process_state == HordeProcessState.INFERENCE_COMPLETE
                         or p.last_process_state == HordeProcessState.WAITING_FOR_JOB
                     ):
                         available_process = p
-            if available_process is None:
-                available_process = self._process_map.get_first_available_inference_process()
 
             if available_process is None:
                 return False

--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -7,7 +7,7 @@ import os
 import random
 import sys
 import time
-from asyncio import CancelledError, Task
+from asyncio import CancelledError
 from asyncio import Lock as Lock_Asyncio
 from collections import deque
 from collections.abc import Mapping
@@ -872,7 +872,9 @@ class HordeWorkerProcessManager:
         :return: None
         """
         self._process_map.update_entry(
-            process_id=process_info.process_id, last_process_state=None, loaded_horde_model_name=None
+            process_id=process_info.process_id,
+            last_process_state=None,
+            loaded_horde_model_name=None,
         )
         try:
             process_info.pipe_connection.send(HordeControlMessage(control_flag=HordeControlFlag.END_PROCESS))


### PR DESCRIPTION
On Linux, it seems like there is a tremendous amount of memory allocated by something outside Python when you allow one worker to process many jobs on many different models. In order to limit the damage from that behavior, we'll try to replace the processes when the model is scheduled to be unloaded.

I realize this probably makes it a _little_ harder to decouple a process from a model, but it's a huge stability improvement.

This also switches the model management strategy a tiny bit by allocating a model to every open worker before trying to unload a model. Previously, you would have
N processes = `threads` + `queue`, but jobs were very likely to be scheduled on only the `threads` number of workers.