### PR TITLE
Fix an error that may occur shortly after worker replacement

### DIFF
--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -125,6 +125,7 @@ class HordeProcessInfo:
         self.process_type = process_type
         self.last_process_state = last_process_state
         self.last_timestamp = datetime.datetime.now()
+        self.last_control_flag = None
 
     def is_process_busy(self) -> bool:
         """Return true if the process is actively engaged in a task.


### PR DESCRIPTION
If a worker is brand new, sometimes in start_inference() the VRAM model eviction might compare against
HordeProcessInfo.last_control_flag and discover that there is no such property.

... and that's how I discovered the field declarations at the top of classes are just documentation, and you still need to assign something in the constructor.