### PR TITLE
fix: make process cycling optional

### DIFF
--- a/horde_worker_regen/bridge_data/data_model.py
+++ b/horde_worker_regen/bridge_data/data_model.py
@@ -25,6 +25,10 @@ class reGenBridgeData(CombinedHordeBridgeData):
 
     _yaml_loader: YAML | None = None
 
+    cycle_process_on_model_change: bool = Field(
+        default=False,
+    )
+
     def load_env_vars(self) -> None:
         """Load the environment variables into the config model."""
         if self.models_folder_parent and os.getenv("AIWORKER_CACHE_HOME") is None:

--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -1213,6 +1213,7 @@ class HordeWorkerProcessManager:
             if (
                 available_process.last_process_state != HordeProcessState.WAITING_FOR_JOB
                 and available_process.loaded_horde_model_name is not None
+                and self.bridge_data.cycle_process_on_model_change
             ):
                 # We're going to restart the process and then exit the loop, because
                 # available_process is very quickly _not_ going to be available.


### PR DESCRIPTION
For Windows users, killing the process before a model change seems wholly unnecessary.

I originally was cycling the processes to deal with the process size bloating to spectacular levels on Linux.