### PR TITLE
Await submit_request when setting follow_up_response

### DIFF
--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -1599,7 +1599,7 @@ class HordeWorkerProcessManager:
                         for (
                             follow_up_request
                         ) in completed_job_info.sdk_api_job_info.get_follow_up_failure_cleanup_request():
-                            follow_up_response = self.horde_client_session.submit_request(
+                            follow_up_response = await self.horde_client_session.submit_request(
                                 follow_up_request,
                                 JobSubmitResponse,
                             )


### PR DESCRIPTION
Awaits an async function that wasn't awaited before, cuasing this error to occur if `image_in_buffer` is None
```py
horde_worker_regen\process_management\process_manager.py:2042: RuntimeWarning: coroutine 'GenericAsyncHordeAPISession.submit_request' was never awaited
  await self.api_submit_job()
  ```