### PR TITLE
fix: restart work after consecutive failed jobs; don't use time.sleep

### DIFF
--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -1901,7 +1901,7 @@ class HordeWorkerProcessManager:
             job_pop_request = ImageGenerateJobPopRequest(
                 apikey=self.bridge_data.api_key,
                 name=self.bridge_data.dreamer_worker_name,
-                bridge_agent="AI Horde Worker reGen:3.0.1:https://github.com/Haidra-Org/horde-worker-reGen",
+                bridge_agent="AI Horde Worker reGen:3.0.2:https://github.com/Haidra-Org/horde-worker-reGen",
                 models=self.bridge_data.image_models_to_load,
                 nsfw=self.bridge_data.nsfw,
                 threads=self.max_concurrent_inference_processes,

--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -1796,7 +1796,7 @@ class HordeWorkerProcessManager:
                         logger.debug(f"{type(e)}: {e}")
                         logger.warning(f"Failed to download {field_name}: {e}")
                         fail_count += 1
-                        time.sleep(0.5)
+                        await asyncio.sleep(0.5)
 
         for field in image_fields:
             try:
@@ -1830,9 +1830,11 @@ class HordeWorkerProcessManager:
             logger.error(
                 "Too many consecutive failed jobs, pausing job pops. "
                 "Please look into what happened and let the devs know. ",
-                "Waiting 300 seconds...",
+                "Waiting 180 seconds...",
             )
-            time.sleep(300)
+            await asyncio.sleep(180)
+            self._consecutive_failed_jobs = 0
+            logger.info("Resuming job pops")
             return
 
         if len(self.job_deque) >= self.bridge_data.queue_size + 1:  # FIXME?


### PR DESCRIPTION
- The 5-minute halt dates back to when the worker was less stable and we were trying to minimize potential issues.
- The use of `time.sleep()` causes the in-process jobs to just abort because its blocking to the other coroutines. This is simply a bug at this point, and has to be changed.
- This change set will give the worker a chance to recover. If this goes on too long, the API will step in with maintenance mode.