### PR TITLE
fix: use model reference version which handles dl fails better

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ torch>=2.1.2
 horde_sdk~=0.7.36
 horde_safety~=0.2.3
 hordelib~=2.4.2
-horde_model_reference
+horde_model_reference~=0.5.4
 
 python-dotenv
 ruamel.yaml


### PR DESCRIPTION
Uses the `horde_model_reference` change ([see here](https://github.com/Haidra-Org/horde-model-reference/commit/0b91300a2bb21e7338a7cc57d9fd2e122491e9aa)) which prevents writing bad responses/error responses for downloads of model reference files (which should always be valid json). The net effect of this change should be that the most recent (valid) model reference would be used in the event the download (which happens every worker start) fails.