### PR TITLE
fix: better message when R2 times out

### DIFF
--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -1693,7 +1693,7 @@ class HordeWorkerProcessManager:
                         new_submit.retry()
                         return new_submit
             except _async_client_exceptions as e:
-                logger.warning("Generation Submit to AI Horde timed out. Will retry.")
+                logger.warning("Upload to AI Horde R2 timed out. Will retry.")
                 logger.debug(f"{type(e).__name__}: {e}")
                 new_submit.retry()
                 return new_submit


### PR DESCRIPTION
Clarifies that the error pertains to `R2`/`S3` specifically, rather than a horde-hosted service.