### PR TITLE
ci: split pre-commit to its own job; test python 3.11 too

### DIFF
--- a/.github/workflows/maintests.yml
+++ b/.github/workflows/maintests.yml
@@ -17,11 +17,18 @@ on:
       - 'requirements.dev.txt'
       - 'requirements.docs.txt'
 jobs:
-  build:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.0
+
+  unit-tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.10"]
+        python: ["3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3
@@ -33,7 +40,5 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade -r requirements.dev.txt
-      - name: Run pre-commit
-        uses: pre-commit/action@v3.0.0
       - name: Run unit tests
         run: tox -e tests-no-api-calls

--- a/.github/workflows/prtests.yml
+++ b/.github/workflows/prtests.yml
@@ -20,11 +20,18 @@ on:
       - 'requirements.dev.txt'
       - 'requirements.docs.txt'
 jobs:
-  build:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.0
+
+  unit-tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.10"]
+        python: ["3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3
@@ -38,7 +45,5 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade -r requirements.dev.txt
-      - name: Run pre-commit
-        uses: pre-commit/action@v3.0.0
       - name: Run unit tests
         run: tox -e tests-no-api-calls


### PR DESCRIPTION
This is a response to the recent tendency of the github runner to run out of disk space due to the duplication of python installs/environments with tox and pre-commit. This also should allow pull requests which are semantically valid to run the unit tests without halting for a simple whitespace or lint violation.