### PR TITLE
fix: use non-breaking model-ref library versions

### DIFF
--- a/horde_worker_regen/__init__.py
+++ b/horde_worker_regen/__init__.py
@@ -7,4 +7,4 @@ from pathlib import Path  # noqa: E402
 
 ASSETS_FOLDER_PATH = Path(__file__).parent / "assets"
 
-__version__ = "4.1.8"
+__version__ = "4.1.9"

--- a/horde_worker_regen/_version_meta.json
+++ b/horde_worker_regen/_version_meta.json
@@ -1,9 +1,9 @@
 {
-    "recommended_version": "4.1.8",
-    "required_min_version": "4.1.8",
-    "required_min_version_update_date": "2024-02-23",
+    "recommended_version": "4.2.0",
+    "required_min_version": "4.1.9",
+    "required_min_version_update_date": "2024-02-31",
     "required_min_version_info": {
-        "4.2.0": {
+        "4.1.9": {
             "reason_for_update": "Model reference handling is changing. Older workers will not be able to handle the new model reference format."
         }
     },

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 --extra-index-url https://download.pytorch.org/whl/cu121
 torch>=2.1.2
 
-horde_sdk~=0.7.39
+horde_sdk~=0.8.0
 horde_safety~=0.2.3
 hordelib~=2.5.3
-horde_model_reference~=0.5.4
+horde_model_reference~=0.6.1
 
 python-dotenv
 ruamel.yaml


### PR DESCRIPTION
Certain changes to the model reference now do not cause crashes