### PR TITLE
feat: `exit_on_unhandled_faults` config option; attempt to recover (or exit) after too long a period of inactivity

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
         - horde_safety
         - torch
         - ruamel.yaml
-        - hordelib==2.6.2
+        - hordelib==2.6.3
         - horde_sdk==0.8.1
         - horde_model_reference==0.6.3
         - semver

--- a/horde-bridge.cmd
+++ b/horde-bridge.cmd
@@ -4,7 +4,7 @@ cd /d %~dp0
 : This first call to runtime activates the environment for the rest of the script
 call runtime python -s -m pip -V
 
-call python -s -m pip install horde_sdk~=0.8.1 horde_model_reference~=0.6.3 hordelib~=2.6.2 -U
+call python -s -m pip install horde_sdk~=0.8.1 horde_model_reference~=0.6.3 hordelib~=2.6.3 -U
 if %ERRORLEVEL% NEQ 0 (
     echo "Please run update-runtime.cmd."
     GOTO END

--- a/horde_worker_regen/__init__.py
+++ b/horde_worker_regen/__init__.py
@@ -8,4 +8,4 @@ from pathlib import Path  # noqa: E402
 
 ASSETS_FOLDER_PATH = Path(__file__).parent / "assets"
 
-__version__ = "4.2.5"
+__version__ = "4.2.6"

--- a/horde_worker_regen/_version_meta.json
+++ b/horde_worker_regen/_version_meta.json
@@ -1,5 +1,5 @@
 {
-    "recommended_version": "4.2.4",
+    "recommended_version": "4.2.6",
     "required_min_version": "4.2.4",
     "required_min_version_update_date": "2024-03-05",
     "required_min_version_info": {
@@ -11,6 +11,9 @@
         },
         "4.2.4": {
             "reason_for_update": "Fixes a bug that causes indefinite worker hangups."
+        },
+        "4.2.6": {
+            "reason_for_update": "Fixes LoRa downloads causing worker instability."
         }
     },
     "beta_version_info": {

--- a/horde_worker_regen/_version_meta.json
+++ b/horde_worker_regen/_version_meta.json
@@ -1,13 +1,16 @@
 {
     "recommended_version": "4.2.4",
-    "required_min_version": "4.2.3",
-    "required_min_version_update_date": "2024-03-09",
+    "required_min_version": "4.2.4",
+    "required_min_version_update_date": "2024-03-05",
     "required_min_version_info": {
         "4.1.9": {
             "reason_for_update": "Model reference handling is changing. Older workers will not be able to handle the new model reference format."
         },
         "4.2.3": {
             "reason_for_update": "Model reference handling is changing. Older workers will not be able to handle the new model reference format."
+        },
+        "4.2.4": {
+            "reason_for_update": "Fixes a bug that causes indefinite worker hangups."
         }
     },
     "beta_version_info": {

--- a/horde_worker_regen/bridge_data/data_model.py
+++ b/horde_worker_regen/bridge_data/data_model.py
@@ -60,6 +60,8 @@ class reGenBridgeData(CombinedHordeBridgeData):
     capture_kudos_training_data: bool = Field(default=False)
     kudos_training_data_file: str | None = Field(default=None)
 
+    exit_on_unhandled_faults: bool = Field(default=False)
+
     @model_validator(mode="after")
     def validate_performance_modes(self) -> reGenBridgeData:
         if self.max_threads == 2 and self.queue_size > 2:

--- a/horde_worker_regen/load_env_vars.py
+++ b/horde_worker_regen/load_env_vars.py
@@ -90,6 +90,8 @@ def load_env_vars() -> None:  # FIXME: there is a dynamic way to do this
             )
             logger.warning(reason_for_update_str)
 
+            os.environ["AIWORKER_NOT_REQUIRED_VERSION"] = "1"
+
         else:
             logger.error(
                 f"Current worker version {horde_worker_regen.__version__} has a required update to "
@@ -102,6 +104,13 @@ def load_env_vars() -> None:  # FIXME: there is a dynamic way to do this
 
             input("Press Enter to continue...")
             exit(1)
+
+    if not semver.compare(horde_worker_regen.__version__, version_meta.recommended_version) >= 0:
+        logger.warning(
+            f"Current worker version {horde_worker_regen.__version__} is not the recommended version. "
+            f"Please consider updating to {version_meta.recommended_version}.",
+        )
+        os.environ["AIWORKER_NOT_RECOMMENDED_VERSION"] = "1"
 
     if version_meta.beta_version_info:
         current_version_semver = semver.VersionInfo.parse(horde_worker_regen.__version__)

--- a/horde_worker_regen/process_management/inference_process.py
+++ b/horde_worker_regen/process_management/inference_process.py
@@ -157,6 +157,7 @@ class HordeInferenceProcess(HordeProcess):
         # TODO
         self.send_heartbeat_message()
 
+    @logger.catch(reraise=True)
     def on_horde_model_state_change(
         self,
         horde_model_name: str,
@@ -241,6 +242,7 @@ class HordeInferenceProcess(HordeProcess):
             horde_model_state=ModelLoadState.ON_DISK,
         )
 
+    @logger.catch(reraise=True)
     def download_aux_models(self, job_info: ImageGenerateJobPopResponse) -> float | None:
         """Download auxiliary models required for the job.
 
@@ -279,7 +281,10 @@ class HordeInferenceProcess(HordeProcess):
                         )
                         performed_a_download = True
                     lora_manager.fetch_adhoc_lora(lora_entry.name, timeout=45, is_version=lora_entry.is_version)
-                lora_manager.wait_for_downloads(45)
+                try:
+                    lora_manager.wait_for_downloads(45)
+                except Exception as e:
+                    logger.error(f"Failed to wait for downloads: {type(e).__name__} {e}")
 
             time_elapsed = round(time.time() - time_start, 2)
 
@@ -291,6 +296,7 @@ class HordeInferenceProcess(HordeProcess):
 
             return None
 
+    @logger.catch(reraise=True)
     def preload_model(
         self,
         horde_model_name: str,
@@ -391,6 +397,7 @@ class HordeInferenceProcess(HordeProcess):
                 self._is_busy = False
             return results
 
+    @logger.catch(reraise=True)
     def unload_models_from_vram(self) -> None:
         """Unload all models from VRAM."""
         from hordelib.comfy_horde import unload_all_models_vram
@@ -413,6 +420,7 @@ class HordeInferenceProcess(HordeProcess):
                 info="No models to unload from VRAM",
             )
 
+    @logger.catch(reraise=True)
     def unload_models_from_ram(self) -> None:
         """Unload all models from RAM."""
         from hordelib.comfy_horde import unload_all_models_ram
@@ -438,6 +446,7 @@ class HordeInferenceProcess(HordeProcess):
         logger.info("Unloaded all models from RAM")
         self._active_model_name = None
 
+    @logger.catch(reraise=True)
     def cleanup_for_exit(self) -> None:
         """Cleanup the process pending a shutdown."""
         self.unload_models_from_ram()
@@ -522,6 +531,7 @@ class HordeInferenceProcess(HordeProcess):
         )
 
     @override
+    @logger.catch(reraise=True)
     def _receive_and_handle_control_message(self, message: HordeControlMessage) -> None:
         """Receive and handle a control message from the main process.
 

--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -2978,6 +2978,7 @@ class HordeWorkerProcessManager:
                 self.jobs_pending_safety_check.clear()
                 self.jobs_lookup.clear()
                 self.jobs_in_progress.clear()
+                self.completed_jobs.clear()  # FIXME: At least try to submit the jobs as faulted
 
                 self._start_timed_shutdown()
 

--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -301,6 +301,10 @@ class ProcessMap(dict[int, HordeProcessInfo]):
             total_vram_bytes (int | None, optional): The total amount of VRAM available to this process. \
                 Defaults to None.
         """
+        if process_id not in self:
+            logger.error(f"Process {process_id} does not exist in the process map")
+            return
+
         if last_process_state is not None:
             self[process_id].last_process_state = last_process_state
 

--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -1116,6 +1116,8 @@ class HordeWorkerProcessManager:
             job_info.time_to_generate = self.bridge_data.process_timeout
             job_info.job_image_results = None
 
+            logger.error(f"Job {job.id_} faulted due to process {process_info.process_id} crashing")
+
             self.completed_jobs.append(job_info)
 
             if job in self.job_pop_timestamps:
@@ -1993,6 +1995,7 @@ class HordeWorkerProcessManager:
         new_submit.succeed(new_submit.kudos_reward, new_submit.kudos_per_second)
         return new_submit
 
+    @logger.catch(reraise=True)
     async def api_submit_job(self) -> None:
         """Submit a job result to the API, if any are completed (safety checked too) and ready to be submitted."""
         if len(self.completed_jobs) == 0:

--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -1107,7 +1107,6 @@ class HordeWorkerProcessManager:
         :return: None
         """
         logger.debug(f"Replacing {process_info}")
-        self._end_inference_process(process_info)
         # job = next(((job, pid) for job, pid in self.jobs_in_progress if pid == process_info.process_id), None)
         job_to_remove = None
         for in_process_job, in_progress_process_info in self.jobs_lookup.items():
@@ -1153,6 +1152,7 @@ class HordeWorkerProcessManager:
             else:
                 logger.warning(f"Job {job_to_remove.id_} not found in job_pop_timestamps")
 
+        self._end_inference_process(process_info)
         self._start_inference_process(process_info.process_id)
 
     total_num_completed_jobs: int = 0

--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -2870,6 +2870,17 @@ class HordeWorkerProcessManager:
 
             logger.success(job_info_message)
 
+            if os.getenv("AIWORKER_NOT_REQUIRED_VERSION"):
+                logger.warning(
+                    "There is a required update available for the AI Worker. "
+                    "`git pull` and `update-runtime` to update.",
+                )
+            elif os.getenv("AIWORKER_NOT_RECOMMENDED_VERSION"):
+                logger.warning(
+                    "There is a recommended update available for the AI Worker. "
+                    "`git pull` and `update-runtime` to update.",
+                )
+
             self._last_status_message_time = time.time()
 
     _bridge_data_loop_interval = 1.0

--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -3021,6 +3021,8 @@ class HordeWorkerProcessManager:
             if len(self.jobs_being_safety_checked) > 0:
                 logger.error("Jobs are still being safety checked...")
 
+            return True
+
         any_replaced = False
         for process_info in self._process_map.values():
             time_elapsed = now - process_info.last_timestamp

--- a/horde_worker_regen/version_meta.py
+++ b/horde_worker_regen/version_meta.py
@@ -15,6 +15,7 @@ class BetaVersionInfo(BaseModel):
 
 
 class VersionMeta(BaseModel):
+    recommended_version: str
     required_min_version: str
     required_min_version_update_date: str
     beta_version_info: dict[str, BetaVersionInfo]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "horde_worker_regen"
-version = "4.2.5"
+version = "4.2.6"
 description = "Allows you to connect to the AI Horde and generate images for users."
 authors = [
     {name = "tazlin", email = "tazlin.on.github@gmail.com"},

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ torch>=2.1.2
 
 horde_sdk~=0.8.1
 horde_safety~=0.2.3
-hordelib~=2.6.2
+hordelib~=2.6.3
 horde_model_reference~=0.6.3
 
 python-dotenv


### PR DESCRIPTION
- Sets the minimum required version of reGen to `4.2.4` due to the critical bug fixes it includes.
- Fixes a critical bug which occurs when a LoRa takes too long to download and can make the worker unstable
- Fixes LoRas retrying taking too long or retrying in doomed situations (such as missing a civitai token)
- Adds a fail-safe zombie detection:
  - If all processes have done nothing (or no jobs were submitted) for the amount of time set by `process_timeout` (900 seconds by default) **AND** the last pop pop message was a valid job pop (and *not* a "no jobs" message)
    - If `exit_on_unhandled_faults` is true
      - The worker attempts to exit as quickly as possible, not reporting any faults.
    - If `exit_on_unhandled_faults` is false (the default)
      - All of the inference processes are restarted and it tries to recover.
- Adds a good deal of logging to help diagnose future problems of this nature.