### PR TITLE
fix: performance improvements; use hordelib w/ lora/ti metadata download fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
         - horde_safety
         - torch
         - ruamel.yaml
-        - hordelib==2.6.3
+        - hordelib==2.6.4
         - horde_sdk==0.8.1
         - horde_model_reference==0.6.3
         - semver

--- a/horde-bridge.cmd
+++ b/horde-bridge.cmd
@@ -4,7 +4,7 @@ cd /d %~dp0
 : This first call to runtime activates the environment for the rest of the script
 call runtime python -s -m pip -V
 
-call python -s -m pip install horde_sdk~=0.8.1 horde_model_reference~=0.6.3 hordelib~=2.6.3 -U
+call python -s -m pip install horde_sdk~=0.8.1 horde_model_reference~=0.6.3 hordelib~=2.6.4 -U
 if %ERRORLEVEL% NEQ 0 (
     echo "Please run update-runtime.cmd."
     GOTO END

--- a/horde_worker_regen/__init__.py
+++ b/horde_worker_regen/__init__.py
@@ -8,4 +8,4 @@ from pathlib import Path  # noqa: E402
 
 ASSETS_FOLDER_PATH = Path(__file__).parent / "assets"
 
-__version__ = "4.2.7"
+__version__ = "4.2.8"

--- a/horde_worker_regen/_version_meta.json
+++ b/horde_worker_regen/_version_meta.json
@@ -1,6 +1,6 @@
 {
     "recommended_version": "4.2.8",
-    "required_min_version": "4.2.8",
+    "required_min_version": "4.2.7",
     "required_min_version_update_date": "2024-03-09",
     "required_min_version_info": {
         "4.1.9": {
@@ -13,6 +13,9 @@
             "reason_for_update": "Fixes a bug that causes indefinite worker hangups."
         },
         "4.2.6": {
+            "reason_for_update": "Fixes LoRa downloads causing worker instability."
+        },
+        "4.2.7": {
             "reason_for_update": "Fixes LoRa downloads causing worker instability."
         }
     },

--- a/horde_worker_regen/_version_meta.json
+++ b/horde_worker_regen/_version_meta.json
@@ -1,7 +1,7 @@
 {
-    "recommended_version": "4.2.6",
-    "required_min_version": "4.2.4",
-    "required_min_version_update_date": "2024-03-05",
+    "recommended_version": "4.2.8",
+    "required_min_version": "4.2.8",
+    "required_min_version_update_date": "2024-03-09",
     "required_min_version_info": {
         "4.1.9": {
             "reason_for_update": "Model reference handling is changing. Older workers will not be able to handle the new model reference format."

--- a/horde_worker_regen/bridge_data/data_model.py
+++ b/horde_worker_regen/bridge_data/data_model.py
@@ -51,6 +51,8 @@ class reGenBridgeData(CombinedHordeBridgeData):
 
     high_memory_mode: bool = Field(default=False)
 
+    very_high_memory_mode: bool = Field(default=False)
+
     high_performance_mode: bool = Field(default=False)
     """If you have a 4090 or better, set this to true to enable high performance mode."""
 
@@ -76,7 +78,13 @@ class reGenBridgeData(CombinedHordeBridgeData):
                 "The queue_size value has been set to 1 because the max_threads value is greater than 2.",
             )
 
-        if self.high_memory_mode:
+        if self.very_high_memory_mode and not self.high_memory_mode:
+            self.high_memory_mode = True
+            logger.warning(
+                "Very high memory mode is enabled, so the high_memory_mode value has been set to True.",
+            )
+
+        if self.high_memory_mode and not self.very_high_memory_mode:
             if self.max_threads != 1:
                 self.max_threads = 1
                 logger.warning(

--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -2419,8 +2419,10 @@ class HordeWorkerProcessManager:
 
         # If there are long running jobs, don't start any more even if there is space in the deque
         if self.should_wait_for_pending_megapixelsteps():
-            if self.get_pending_megapixelsteps() < 100:
-                seconds_to_wait = self.get_pending_megapixelsteps() * 0.8
+            if self.get_pending_megapixelsteps() < 40:
+                seconds_to_wait = self.get_pending_megapixelsteps() * 0.5
+            elif self.get_pending_megapixelsteps() < 80:
+                seconds_to_wait = self.get_pending_megapixelsteps() * 0.7
             else:
                 seconds_to_wait = self.get_pending_megapixelsteps() * 0.9
 

--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -2559,15 +2559,15 @@ class HordeWorkerProcessManager:
 
             # TODO: horde_sdk should handle this and return a field with a enum(?) of the reason
             if isinstance(job_pop_response, RequestErrorResponse):
-                if "maintenance mode" in job_pop_response.message:
+                if "maintenance mode" in job_pop_response.message.lower():
                     logger.warning(f"Failed to pop job (Maintenance Mode): {job_pop_response}")
-                elif "we cannot accept workers serving" in job_pop_response.message:
+                elif "we cannot accept workers serving" in job_pop_response.message.lower():
                     logger.warning(f"Failed to pop job (Unrecognized Model): {job_pop_response}")
                     logger.error(
                         "Your worker is configured to use a model that is not accepted by the API. "
                         "Please check your models_to_load and make sure they are all valid.",
                     )
-                elif "wrong credentials" in job_pop_response.message:
+                elif "wrong credentials" in job_pop_response.message.lower():
                     logger.warning(f"Failed to pop job (Wrong Credentials): {job_pop_response}")
                     logger.error("Did you forget to set your worker name?")
                 else:

--- a/horde_worker_regen/run_worker.py
+++ b/horde_worker_regen/run_worker.py
@@ -1,5 +1,7 @@
 """The main entry point for the reGen worker."""
+import contextlib
 import io
+import multiprocessing
 import os
 import sys
 
@@ -7,10 +9,15 @@ os.environ["HORDE_SDK_DISABLE_CUSTOM_SINKS"] = "1"
 
 from horde_worker_regen.load_env_vars import load_env_vars
 
-load_env_vars()
+import_context: contextlib.AbstractContextManager = contextlib.nullcontext()
+
+if multiprocessing.current_process().name != "MainProcess":
+    import_context = contextlib.redirect_stdout(None)
+
+with import_context:
+    load_env_vars()
+
 import argparse
-import contextlib
-import multiprocessing
 import time
 from multiprocessing.context import BaseContext
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "horde_worker_regen"
-version = "4.2.7"
+version = "4.2.8"
 description = "Allows you to connect to the AI Horde and generate images for users."
 authors = [
     {name = "tazlin", email = "tazlin.on.github@gmail.com"},

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ torch>=2.1.2
 
 horde_sdk~=0.8.1
 horde_safety~=0.2.3
-hordelib~=2.6.3
+hordelib~=2.6.4
 horde_model_reference~=0.6.3
 
 python-dotenv


### PR DESCRIPTION
- Fixes some issues when downloading LoRas and CivitAI acts unpredictably, experiences issues, or is excessively slow.
  - See https://github.com/Haidra-Org/hordelib/pull/211 for a more detailed explanation.
- Tweaks the parameters surrounding the timing for job pops, which means that the worker should now only pop jobs at more reasonable times and that jobs will not be queued for any more time than is necessary. This shouldn't affect kudos/hr dramatically, but it should have a noticeable impact on the MPS ('performance') stat as seen on the `workers` stats endpoints.
  - It should be noted that jobs that are bound by download speed will not always block the worker from working as of https://github.com/Haidra-Org/horde-worker-reGen/pull/139, and so being more conservative with the frequency of job pop - and therefore potentially leaving less time for downloads - has become less of an issue.