### PR TITLE
fix: improved heartbeat (process stalled) logic

### DIFF
--- a/horde_worker_regen/process_management/inference_process.py
+++ b/horde_worker_regen/process_management/inference_process.py
@@ -431,7 +431,7 @@ class HordeInferenceProcess(HordeProcess):
             except Exception as e:
                 logger.error(f"Failed to release inference semaphore: {type(e).__name__} {e}")
 
-        if progress_report.comfyui_progress is not None and progress_report.comfyui_progress.current_step >= 0:
+        if progress_report.comfyui_progress is not None and progress_report.comfyui_progress.current_step > 0:
             self.send_heartbeat_message(heartbeat_type=HordeHeartbeatType.INFERENCE_STEP)
         else:
             self.send_heartbeat_message(heartbeat_type=HordeHeartbeatType.PIPELINE_STATE_CHANGE)

--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -454,7 +454,7 @@ class ProcessMap(dict[int, HordeProcessInfo]):
             return False
         if (
             self[process_id].last_heartbeat_type == HordeHeartbeatType.INFERENCE_STEP
-            and (time.time() - self[process_id].last_heartbeat_timestamp) > 30
+            and (time.time() - self[process_id].last_heartbeat_timestamp) > 45
         ):
             return True
         return False


### PR DESCRIPTION
This prevents the heartbeat rate limiting from coming into play. Logic elsewhere relies on heartbeat messages changing being noticed, but the rate-limiting would occasionally prevent messages from being sent. 

This should minimize a category of problems surrounding nodes that *should* take a long time run being incorrectly categorized as an inference step and the worker killing the process in error.
