### PR TITLE
fix: handle more corner cases with job upload/submit

### DIFF
--- a/horde_worker_regen/__init__.py
+++ b/horde_worker_regen/__init__.py
@@ -8,4 +8,4 @@ from pathlib import Path  # noqa: E402
 
 ASSETS_FOLDER_PATH = Path(__file__).parent / "assets"
 
-__version__ = "5.0.1"
+__version__ = "5.0.2"

--- a/horde_worker_regen/_version_meta.json
+++ b/horde_worker_regen/_version_meta.json
@@ -1,5 +1,5 @@
 {
-    "recommended_version": "5.0.1",
+    "recommended_version": "5.0.2",
     "required_min_version": "4.2.7",
     "required_min_version_update_date": "2024-03-09",
     "required_min_version_info": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "horde_worker_regen"
-version = "5.0.1"
+version = "5.0.2"
 description = "Allows you to connect to the AI Horde and generate images for users."
 authors = [
     {name = "tazlin", email = "tazlin.on.github@gmail.com"},


### PR DESCRIPTION
Some observed behavior on a worker machine indicates that the submit step has some code which may lead to worker lockups. I cannot fully account for the nature of those lockups, and this PR serves as an attempt to potentially resolve the problem, and in lieu of that, at least provide slightly more information to help root out the problem.