### PR TITLE
fix: handle custom models in `keep_single_inference`

### DIFF
--- a/horde_worker_regen/__init__.py
+++ b/horde_worker_regen/__init__.py
@@ -8,7 +8,7 @@ from pathlib import Path  # noqa: E402
 
 ASSETS_FOLDER_PATH = Path(__file__).parent / "assets"
 
-__version__ = "7.0.1"
+__version__ = "7.0.2"
 
 
 import pkg_resources  # noqa: E402

--- a/horde_worker_regen/_version_meta.json
+++ b/horde_worker_regen/_version_meta.json
@@ -1,5 +1,5 @@
 {
-    "recommended_version": "7.0.1",
+    "recommended_version": "7.0.2",
     "required_min_version": "4.2.7",
     "required_min_version_update_date": "2024-03-09",
     "required_min_version_info": {

--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -519,7 +519,11 @@ class ProcessMap(dict[int, HordeProcessInfo]):
                     )
                     continue
 
-                model_info = stable_diffusion_model_reference.root[model]
+                model_info = stable_diffusion_model_reference.root.get(model)
+                if model_info is None:
+                    logger.debug(f"Model {model} not found in stable diffusion model reference. Is it a custom model?")
+                    continue
+
                 if model_info.baseline == STABLE_DIFFUSION_BASELINE_CATEGORY.stable_diffusion_xl and (
                     p.can_accept_job()
                     or p.last_process_state == HordeProcessState.PRELOADING_MODEL

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "horde_worker_regen"
-version = "7.0.1"
+version = "7.0.2"
 description = "Allows you to connect to the AI Horde and generate images for users."
 authors = [
     {name = "tazlin", email = "tazlin.on.github@gmail.com"},


### PR DESCRIPTION
This should prevent crashes when QR code/CN workflows are used with custom models