### PR TITLE
fix: pin `numpy` to 1.26.4 (v2 is breaking)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+numpy==1.26.4
 torch==2.2.2
 
 horde_sdk~=0.10.0


### PR DESCRIPTION
As detailed [here](https://numpy.org/doc/stable/release/2.0.0-notes.html), v2.0.0 of numpy has numerous breaking changes. Notably, torch relies on numpy but does not support v2. This prevents new installs (or updates with the `-U` switch) from using this presently incompatible version of numpy.