### PR TITLE
fix: asyncio win loop policy fix

### DIFF
--- a/horde_worker_regen/__init__.py
+++ b/horde_worker_regen/__init__.py
@@ -8,7 +8,7 @@ from pathlib import Path  # noqa: E402
 
 ASSETS_FOLDER_PATH = Path(__file__).parent / "assets"
 
-__version__ = "8.1.1"
+__version__ = "8.1.2"
 
 
 import pkg_resources  # noqa: E402

--- a/horde_worker_regen/_version_meta.json
+++ b/horde_worker_regen/_version_meta.json
@@ -1,5 +1,5 @@
 {
-    "recommended_version": "8.1.1",
+    "recommended_version": "8.1.2",
     "required_min_version": "4.2.7",
     "required_min_version_update_date": "2024-03-09",
     "required_min_version_info": {

--- a/horde_worker_regen/run_worker.py
+++ b/horde_worker_regen/run_worker.py
@@ -1,11 +1,17 @@
 """The main entry point for the reGen worker."""
 
+import sys
+
+if sys.platform == "win32":
+    import asyncio
+
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
 import argparse
 import contextlib
 import io
 import multiprocessing
 import os
-import sys
 import time
 from multiprocessing.context import BaseContext
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "horde_worker_regen"
-version = "8.1.1"
+version = "8.1.2"
 description = "Allows you to connect to the AI Horde and generate images for users."
 authors = [
     {name = "tazlin", email = "tazlin.on.github@gmail.com"},

--- a/tests/test_horde_dep_updates.py
+++ b/tests/test_horde_dep_updates.py
@@ -3,10 +3,10 @@ from pathlib import Path
 HORDE_BRIDGE_SCRIPT = Path(__file__).parent.parent / "horde-bridge.cmd"
 
 
-def test_horde_bridge_updating(horde_dependency_versions: list[tuple[str, str]]) -> None:
+def test_horde_bridge_updating(horde_dependency_versions: dict[str, str]) -> None:
     """Check that the versions of horde deps. in horde-bridge.cmd match the versions in requirements.txt."""
     haidra_dep_string = "horde"
-    haidra_deps = [(dep, version) for dep, version in horde_dependency_versions if haidra_dep_string in dep]
+    haidra_deps = [(dep, version) for dep, version in horde_dependency_versions.items() if haidra_dep_string in dep]
 
     script_lines = HORDE_BRIDGE_SCRIPT.read_text().split("\n")
 


### PR DESCRIPTION
I am unclear on the exact package causing this issue but my guess is that the call (`asyncio.set_event_loop_policy(...)`) either was previously happening elsewhere or is now being overridden somehow in the latest version of a package.

The error that occurs without this fix directs you to https://github.com/saghul/aiodns/issues/86 which indicates the fix used in this commit.