### PR TITLE
feat: allow setting worker name via env var or cli arg

### DIFF
--- a/horde_worker_regen/bridge_data/data_model.py
+++ b/horde_worker_regen/bridge_data/data_model.py
@@ -204,6 +204,20 @@ class reGenBridgeData(CombinedHordeBridgeData):
         if self.max_lora_cache_size and os.getenv("AIWORKER_LORA_CACHE_SIZE") is None:
             os.environ["AIWORKER_LORA_CACHE_SIZE"] = str(self.max_lora_cache_size * 1024)
 
+        self.dreamer_override_worker_name = os.environ.get("AIWORKER_DREAMER_WORKER_NAME")
+
+    _override_worker_name: str | None = None
+
+    def get_worker_name(self) -> str:
+        """Get the worker name, preferring the override name if set.
+
+        Returns:
+            str: The worker name.
+        """
+        if self._override_worker_name:
+            return self._override_worker_name
+        return self.dreamer_worker_name
+
     def save(self, file_path: str) -> None:
         """Save the config model to a file.
 

--- a/horde_worker_regen/bridge_data/data_model.py
+++ b/horde_worker_regen/bridge_data/data_model.py
@@ -206,6 +206,8 @@ class reGenBridgeData(CombinedHordeBridgeData):
 
         self.dreamer_override_worker_name = os.environ.get("AIWORKER_DREAMER_WORKER_NAME")
 
+        logger.debug(f"AIWORKER_DREAMER_WORKER_NAME: {self.dreamer_override_worker_name}")
+
     _override_worker_name: str | None = None
 
     def get_worker_name(self) -> str:

--- a/horde_worker_regen/bridge_data/data_model.py
+++ b/horde_worker_regen/bridge_data/data_model.py
@@ -7,7 +7,7 @@ import os
 
 from horde_sdk.ai_horde_worker.bridge_data import CombinedHordeBridgeData
 from loguru import logger
-from pydantic import Field, model_validator, field_validator
+from pydantic import Field, field_validator, model_validator
 from ruamel.yaml import YAML
 
 from horde_worker_regen.consts import TOTAL_LORA_DOWNLOAD_TIMEOUT
@@ -133,6 +133,7 @@ class reGenBridgeData(CombinedHordeBridgeData):
 
     @field_validator("dreamer_worker_name", mode="after")
     def validate_dreamer_worker_name(cls, value: str) -> str:
+        """Apply the environment variable override for the `dreamer_worker_name` field."""
         if os.getenv("AIWORKER_DREAMER_WORKER_NAME"):
             logger.warning(
                 "AIWORKER_DREAMER_WORKER_NAME environment variable is set. This will override the value for "

--- a/horde_worker_regen/bridge_data/data_model.py
+++ b/horde_worker_regen/bridge_data/data_model.py
@@ -134,12 +134,13 @@ class reGenBridgeData(CombinedHordeBridgeData):
     @field_validator("dreamer_worker_name", mode="after")
     def validate_dreamer_worker_name(cls, value: str) -> str:
         """Apply the environment variable override for the `dreamer_worker_name` field."""
-        if os.getenv("AIWORKER_DREAMER_WORKER_NAME"):
+        AIWORKER_DREAMER_WORKER_NAME = os.getenv("AIWORKER_DREAMER_WORKER_NAME")
+        if AIWORKER_DREAMER_WORKER_NAME:
             logger.warning(
                 "AIWORKER_DREAMER_WORKER_NAME environment variable is set. This will override the value for "
                 "`dreamer_worker_name` in the config file.",
             )
-            return os.getenv("AIWORKER_DREAMER_WORKER_NAME")
+            return AIWORKER_DREAMER_WORKER_NAME
 
         return value
 

--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -3226,7 +3226,7 @@ class HordeWorkerProcessManager:
         try:
             job_pop_request = ImageGenerateJobPopRequest(
                 apikey=self.bridge_data.api_key,
-                name=self.bridge_data.get_worker_name(),
+                name=self.bridge_data.dreamer_worker_name,
                 bridge_agent=f"AI Horde Worker reGen:{horde_worker_regen.__version__}:https://github.com/Haidra-Org/horde-worker-reGen",
                 models=list(models),
                 blacklist=self.bridge_data.blacklist,
@@ -3630,7 +3630,7 @@ class HordeWorkerProcessManager:
             logger.info(
                 " | ".join(
                     [
-                        f"dreamer_name: {self.bridge_data.get_worker_name()}",
+                        f"dreamer_name: {self.bridge_data.dreamer_worker_name}",
                         f"(v{horde_worker_regen.__version__})",
                         f"max_power: {self.bridge_data.max_power}",
                         f"max_threads: {self.max_concurrent_inference_processes}",

--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -3226,7 +3226,7 @@ class HordeWorkerProcessManager:
         try:
             job_pop_request = ImageGenerateJobPopRequest(
                 apikey=self.bridge_data.api_key,
-                name=self.bridge_data.dreamer_worker_name,
+                name=self.bridge_data.get_worker_name(),
                 bridge_agent=f"AI Horde Worker reGen:{horde_worker_regen.__version__}:https://github.com/Haidra-Org/horde-worker-reGen",
                 models=list(models),
                 blacklist=self.bridge_data.blacklist,
@@ -3630,7 +3630,7 @@ class HordeWorkerProcessManager:
             logger.info(
                 " | ".join(
                     [
-                        f"dreamer_name: {self.bridge_data.dreamer_worker_name}",
+                        f"dreamer_name: {self.bridge_data.get_worker_name()}",
                         f"(v{horde_worker_regen.__version__})",
                         f"max_power: {self.bridge_data.max_power}",
                         f"max_threads: {self.max_concurrent_inference_processes}",

--- a/horde_worker_regen/run_worker.py
+++ b/horde_worker_regen/run_worker.py
@@ -165,7 +165,8 @@ def init() -> None:
 
     os.environ["HORDE_SDK_DISABLE_CUSTOM_SINKS"] = "1"
 
-    os.environ["AIWORKER_DREAMER_WORKER_NAME"] = args.worker_name
+    if args.worker_name:
+        os.environ["AIWORKER_DREAMER_WORKER_NAME"] = args.worker_name
 
     from horde_worker_regen.load_env_vars import load_env_vars_from_config
 

--- a/horde_worker_regen/run_worker.py
+++ b/horde_worker_regen/run_worker.py
@@ -153,10 +153,19 @@ def init() -> None:
         default=False,
         help="Enable AMD GPU-specific optimisations",
     )
+    parser.add_argument(
+        "-n",
+        "--worker-name",
+        type=str,
+        default=None,
+        help="Override the worker name from the config file, for running multiple workers on one machine",
+    )
 
     args = parser.parse_args()
 
     os.environ["HORDE_SDK_DISABLE_CUSTOM_SINKS"] = "1"
+
+    os.environ["AIWORKER_DREAMER_WORKER_NAME"] = args.worker_name
 
     from horde_worker_regen.load_env_vars import load_env_vars_from_config
 


### PR DESCRIPTION
- `AIWORKER_DREAMER_WORKER_NAME` will now override what is set for `dreamer_name`/`dreamer_worker_name` in `bridgeData.yaml`
- The `run_worker.py` cli arg `-w`/`--worker-name` has the same effect
  - Note that this also applies to `horde-bridge.cmd` and `horde-bridge.sh` as the arguments passed to them are carried through to `run_worker.py`