### PR TITLE
fix: run conda commands relative to linux script

### DIFF
--- a/horde-bridge-rocm.sh
+++ b/horde-bridge-rocm.sh
@@ -41,9 +41,9 @@ if [ -z "$LD_PRELOAD" ]; then
 fi
 
 
-if ./runtime-rocm.sh python -s download_models.py; then
+if "$SCRIPT_DIR/runtime-rocm.sh" python -s "$SCRIPT_DIR/download_models.py"; then
     echo "Model Download OK. Starting worker..."
-    ./runtime-rocm.sh python -s run_worker.py --amd $*
+    "$SCRIPT_DIR/runtime-rocm.sh" python -s "$SCRIPT_DIR/run_worker.py" --amd $*
 else
     echo "download_models.py exited with error code. Aborting"
 fi

--- a/horde-bridge.sh
+++ b/horde-bridge.sh
@@ -37,10 +37,9 @@ if [ -z "$LD_PRELOAD" ]; then
     fi
 fi
 
-
-if ./runtime.sh python -s download_models.py; then
+if "$SCRIPT_DIR/runtime.sh" python -s "$SCRIPT_DIR/download_models.py"; then
     echo "Model Download OK. Starting worker..."
-    ./runtime.sh python -s run_worker.py $*
+    "$SCRIPT_DIR/runtime.sh" python -s "$SCRIPT_DIR/run_worker.py" $*
 else
     echo "download_models.py exited with error code. Aborting"
 fi

--- a/runtime-rocm.sh
+++ b/runtime-rocm.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-if [ ! -f "conda/envs/linux/bin/python" ]; then
-./update-runtime-rocm.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ ! -f "$SCRIPT_DIR/conda/envs/linux/bin/python" ]; then
+"$SCRIPT_DIR/update-runtime-rocm.sh"
 fi
-bin/micromamba run -r conda -n linux "$@"
+"$SCRIPT_DIR/bin/micromamba" run -r "$SCRIPT_DIR/conda" -n linux "$@"

--- a/runtime.sh
+++ b/runtime.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-if [ ! -f "conda/envs/linux/bin/python" ]; then
-./update-runtime.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ ! -f "$SCRIPT_DIR/conda/envs/linux/bin/python" ]; then
+"$SCRIPT_DIR/update-runtime.sh"
 fi
-bin/micromamba run -r conda -n linux "$@"
+"$SCRIPT_DIR/bin/micromamba" run -r "$SCRIPT_DIR/conda" -n linux "$@"

--- a/update-runtime-rocm.sh
+++ b/update-runtime-rocm.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 ignore_hordelib=false
 
@@ -26,18 +27,18 @@ done
 
 CONDA_ENVIRONMENT_FILE=environment.rocm.yaml
 
-wget -qO- https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-linux-64.tar.bz2 | tar -xvj bin/micromamba
-if [ ! -f "conda/envs/linux/bin/python" ]; then
-    bin/micromamba create --no-shortcuts -r conda -n linux -f ${CONDA_ENVIRONMENT_FILE} -y
+wget -qO- https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-linux-64.tar.bz2 | tar -xvj "$SCRIPT_DIR/bin/micromamba"
+if [ ! -f "$SCRIPT_DIR/conda/envs/linux/bin/python" ]; then
+    bin/micromamba create --no-shortcuts -r "$SCRIPT_DIR/conda" -n linux -f ${CONDA_ENVIRONMENT_FILE} -y
 fi
-bin/micromamba create --no-shortcuts -r conda -n linux -f ${CONDA_ENVIRONMENT_FILE} -y
+bin/micromamba create --no-shortcuts -r "$SCRIPT_DIR/conda" -n linux -f ${CONDA_ENVIRONMENT_FILE} -y
 
 if [ "$hordelib" = true ]; then
- bin/micromamba run -r conda -n linux python -s -m pip uninstall -y hordelib horde_engine horde_sdk horde_model_reference
- bin/micromamba run -r conda -n linux python -s -m pip install horde_engine horde_model_reference --extra-index-url https://download.pytorch.org/whl/rocm6.0
+ bin/micromamba run -r "$SCRIPT_DIR/conda" -n linux python -s -m pip uninstall -y hordelib horde_engine horde_sdk horde_model_reference
+ bin/micromamba run -r "$SCRIPT_DIR/conda" -n linux python -s -m pip install horde_engine horde_model_reference --extra-index-url https://download.pytorch.org/whl/rocm6.1
 else
- bin/micromamba run -r conda -n linux python -s -m pip install -r requirements.rocm.txt -U --extra-index-url https://download.pytorch.org/whl/rocm6.0
+ bin/micromamba run -r "$SCRIPT_DIR/conda" -n linux python -s -m pip install -r "$SCRIPT_DIR/requirements.rocm.txt" -U --extra-index-url https://download.pytorch.org/whl/rocm6.1
 
 fi
 
-bin/micromamba run -r conda -n linux horde_worker_regen/amd_go_fast/install_amd_go_fast.sh
+bin/micromamba run -r "$SCRIPT_DIR/conda" -n linux "$SCRIPT_DIR/horde_worker_regen/amd_go_fast/install_amd_go_fast.sh"

--- a/update-runtime.sh
+++ b/update-runtime.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 ignore_hordelib=false
 
@@ -26,15 +27,15 @@ done
 
 CONDA_ENVIRONMENT_FILE=environment.yaml
 
-wget -qO- https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-linux-64.tar.bz2 | tar -xvj bin/micromamba
-if [ ! -f "conda/envs/linux/bin/python" ]; then
-    bin/micromamba create --no-shortcuts -r conda -n linux -f ${CONDA_ENVIRONMENT_FILE} -y
+wget -qO- https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-linux-64.tar.bz2 | tar -xvj "$SCRIPT_DIR/bin/micromamba"
+if [ ! -f "$SCRIPT_DIR/conda/envs/linux/bin/python" ]; then
+    bin/micromamba create --no-shortcuts -r "$SCRIPT_DIR/conda" -n linux -f ${CONDA_ENVIRONMENT_FILE} -y
 fi
-bin/micromamba create --no-shortcuts -r conda -n linux -f ${CONDA_ENVIRONMENT_FILE} -y
+bin/micromamba create --no-shortcuts -r "$SCRIPT_DIR/conda" -n linux -f ${CONDA_ENVIRONMENT_FILE} -y
 
 if [ "$hordelib" = true ]; then
- bin/micromamba run -r conda -n linux python -s -m pip uninstall -y hordelib horde_engine horde_sdk horde_model_reference
- bin/micromamba run -r conda -n linux python -s -m pip install horde_engine horde_model_reference --extra-index-url https://download.pytorch.org/whl/cu121
+ bin/micromamba run -r "$SCRIPT_DIR/conda" -n linux python -s -m pip uninstall -y hordelib horde_engine horde_sdk horde_model_reference
+ bin/micromamba run -r "$SCRIPT_DIR/conda" -n linux python -s -m pip install horde_engine horde_model_reference --extra-index-url https://download.pytorch.org/whl/cu121
 else
- bin/micromamba run -r conda -n linux python -s -m pip install -r requirements.txt -U --extra-index-url https://download.pytorch.org/whl/cu121
+ bin/micromamba run -r "$SCRIPT_DIR/conda" -n linux python -s -m pip install -r "$SCRIPT_DIR/requirements.txt" -U --extra-index-url https://download.pytorch.org/whl/cu121
 fi


### PR DESCRIPTION
This allows your PWD do be used to isolate multiple configs and sets of logs when running more than one worker instance on a single machine