### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ You can double click the provided script files below from a file explorer or run
 
 ### Configure
 
-1. Make a copy of `bridgeData_template.yaml` to `bridgeData.yaml`
+1. Rename `bridgeData_template.yaml` to `bridgeData.yaml`
 1. Edit `bridgeData.yaml` and follow the instructions within to fill in your details.
 
 


### PR DESCRIPTION
"make a copy of" is confusing: I get the intended purpose of the user making such a copy, but then the question comes up if keeping the original document will break the code in any way; renaming the file removes that concern. If the file breaks in any way where the original is needed, downloading the file again from the repo could be utilized