### PR TITLE
feat: `load_large_models` for model meta

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,6 @@ repos:
         - torch==2.3.1
         - ruamel.yaml
         - horde_engine==2.15.2
-        - horde_sdk==0.14.7
+        - horde_sdk==0.14.8
         - horde_model_reference==0.9.0
         - semver

--- a/bridgeData_template.yaml
+++ b/bridgeData_template.yaml
@@ -226,6 +226,12 @@ models_to_load:
   #- "Anything Diffusion"
   #- "stable_diffusion_inpainting"
 
+# If you use a meta command, such as ALL or TOP n, you can allow very large models, such as cascade or flux to be included.
+# By default, these models are excluded due to their large size.
+# Set to true if have a 24GB card and want to include these models.
+# Otherwise, I suggest including the models you know you can handle manually.
+load_large_models: false
+
 # Models to skip when `dynamic_models` is true or TOP n models are selected in models_to_load.
 # Avoid loading models due to VRAM constraints, NSFW content, or other reasons.
 models_to_skip:

--- a/horde-bridge.cmd
+++ b/horde-bridge.cmd
@@ -5,7 +5,7 @@ cd /d %~dp0
 call runtime python -s -m pip -V
 
 call python -s -m pip uninstall hordelib
-call python -s -m pip install horde_sdk~=0.14.7 horde_model_reference~=0.9.0 horde_engine~=2.15.2 horde_safety~=0.2.3 -U
+call python -s -m pip install horde_sdk~=0.14.8 horde_model_reference~=0.9.0 horde_engine~=2.15.2 horde_safety~=0.2.3 -U
 
 if %ERRORLEVEL% NEQ 0 (
     echo "Please run update-runtime.cmd."

--- a/horde_worker_regen/__init__.py
+++ b/horde_worker_regen/__init__.py
@@ -8,7 +8,7 @@ from pathlib import Path  # noqa: E402
 
 ASSETS_FOLDER_PATH = Path(__file__).parent / "assets"
 
-__version__ = "9.0.2"
+__version__ = "9.0.3"
 
 
 import pkg_resources  # noqa: E402

--- a/horde_worker_regen/_version_meta.json
+++ b/horde_worker_regen/_version_meta.json
@@ -1,5 +1,5 @@
 {
-    "recommended_version": "9.0.2",
+    "recommended_version": "9.0.3",
     "required_min_version": "9.0.2",
     "required_min_version_update_date": "2024-09-26",
     "required_min_version_info": {
@@ -23,6 +23,10 @@
         }
     },
     "beta_version_info": {
+        "9.0.3": {
+            "horde_model_reference_branch": "flux",
+            "beta_expiry_date": "2024-09-30"
+        },
         "9.0.2": {
             "horde_model_reference_branch": "flux",
             "beta_expiry_date": "2024-9-30"

--- a/horde_worker_regen/bridge_data/data_model.py
+++ b/horde_worker_regen/bridge_data/data_model.py
@@ -78,6 +78,8 @@ class reGenBridgeData(CombinedHordeBridgeData):
 
     remove_maintenance_on_init: bool = Field(default=False)
 
+    load_large_models: bool = Field(default=False)
+
     custom_models: list[dict] = Field(
         default_factory=list,
     )
@@ -258,6 +260,9 @@ class reGenBridgeData(CombinedHordeBridgeData):
 
         if self.max_lora_cache_size and os.getenv("AIWORKER_LORA_CACHE_SIZE") is None:
             os.environ["AIWORKER_LORA_CACHE_SIZE"] = str(self.max_lora_cache_size * 1024)
+
+        if self.load_large_models:
+            os.environ["AI_HORDE_MODEL_META_LARGE_MODELS"] = "true"
 
     def save(self, file_path: str) -> None:
         """Save the config model to a file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "horde_worker_regen"
-version = "9.0.2"
+version = "9.0.3"
 description = "Allows you to connect to the AI Horde and generate images for users."
 authors = [
     {name = "tazlin", email = "tazlin.on.github@gmail.com"},

--- a/requirements.rocm.txt
+++ b/requirements.rocm.txt
@@ -1,7 +1,7 @@
 numpy==1.26.4
 torch==2.3.1+rocm6.0
 
-horde_sdk~=0.14.7
+horde_sdk~=0.14.8
 horde_safety~=0.2.3
 horde_engine~=2.15.2
 horde_model_reference~=0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy==1.26.4
 torch==2.3.1
 
-horde_sdk~=0.14.7
+horde_sdk~=0.14.8
 horde_safety~=0.2.3
 horde_engine~=2.15.2
 horde_model_reference>=0.9.0


### PR DESCRIPTION
The `load_large_models: false` configuration option prevents extremely heavy VRAM models (such as cascade or flux) from being included by default through meta commands such as TOP N or ALL.