### PR TITLE
fix: set `AI_HORDE_URL` before horde_sdk import

### DIFF
--- a/bridgeData_template.yaml
+++ b/bridgeData_template.yaml
@@ -5,7 +5,7 @@
 # !!!  !!!  !!!  !!!  !!!  !!!  !!!  !!!  !!!  !!!  !!!  !!!  !!!  !!!  !!!  !!!  !!!
 
 # The Horde URL. Do not change this unless you are using a custom Horde.
-horde_url: "https://aihorde.net"
+horde_url: "https://aihorde.net/api/"
 
 # The API key identifies a unique user in the Horde
 # Visit https://aihorde.net/register to create one before you can join

--- a/horde_worker_regen/load_env_vars.py
+++ b/horde_worker_regen/load_env_vars.py
@@ -57,6 +57,21 @@ def load_env_vars_from_config() -> None:  # FIXME: there is a dynamic way to do 
                 "This will override the value for `civitai_api_token` in the config file.",
             )
 
+    if "horde_url" in config:
+        known_ai_horde_urls = [
+            "stablehorde.net",
+            "aihorde.net",
+        ]
+
+        custom_horde_url = config["horde_url"]
+        if custom_horde_url and any(url in custom_horde_url for url in known_ai_horde_urls):
+            logger.debug("Using default AI Horde URL.")
+        else:
+            logger.warning(
+                f"Using custom AI Horde URL `{custom_horde_url}`. Make sure this is correct and ends in `/api/`.",
+            )
+            os.environ["AI_HORDE_URL"] = custom_horde_url
+
 
 if __name__ == "__main__":
     load_env_vars_from_config()


### PR DESCRIPTION
This causes the config option `horde_url` to work as expected. Previously, it was effectively ignored.

- Note that a check is made for the 'old' style URL, without the expected `/api/`, which was the previous default to allow for backwards compatibility. If known horde urls are detected, the SDK default value is used.