### PR TITLE
fix: mark all non-censored nsfw images in info

### DIFF
--- a/horde_worker_regen/__init__.py
+++ b/horde_worker_regen/__init__.py
@@ -8,7 +8,7 @@ from pathlib import Path  # noqa: E402
 
 ASSETS_FOLDER_PATH = Path(__file__).parent / "assets"
 
-__version__ = "9.0.5"
+__version__ = "9.0.6"
 
 
 import pkg_resources  # noqa: E402

--- a/horde_worker_regen/_version_meta.json
+++ b/horde_worker_regen/_version_meta.json
@@ -1,5 +1,5 @@
 {
-    "recommended_version": "9.0.5",
+    "recommended_version": "9.0.6",
     "required_min_version": "9.0.2",
     "required_min_version_update_date": "2024-09-26",
     "required_min_version_info": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "horde_worker_regen"
-version = "9.0.5"
+version = "9.0.6"
 description = "Allows you to connect to the AI Horde and generate images for users."
 authors = [
     {name = "tazlin", email = "tazlin.on.github@gmail.com"},


### PR DESCRIPTION
Currently the logic doesn't mark nsfw images with the information metadata if they were not censored. Changed it so that it marks them as NSFW always, but only if they were not censored.

The logic here is that the information here pertains to the actual content of the returned image, which in the case of censored images, is actually the SFW warning replacement. 

Supercedes #298 