### PR TITLE
fix: don't count time with any job popped as "no job" time; add way to suppress job time warnings

### DIFF
--- a/bridgeData_template.yaml
+++ b/bridgeData_template.yaml
@@ -261,7 +261,7 @@ models_to_skip:
 # Suppress speed warnings if jobs are taking too long.
 # Note: If you are getting these messages, you are serving jobs much slower than ideal.
 # Lower your max_power for more kudos/hr.
-suppress_speed_warnings: false # Currently unused in reGen
+suppress_speed_warnings: false
 
 # Exit if an unhandled fault occurs. Useful for setting up the worker as a system service.
 exit_on_unhandled_faults: false

--- a/horde_worker_regen/__init__.py
+++ b/horde_worker_regen/__init__.py
@@ -8,7 +8,7 @@ from pathlib import Path  # noqa: E402
 
 ASSETS_FOLDER_PATH = Path(__file__).parent / "assets"
 
-__version__ = "9.0.6"
+__version__ = "9.0.7"
 
 
 import pkg_resources  # noqa: E402

--- a/horde_worker_regen/_version_meta.json
+++ b/horde_worker_regen/_version_meta.json
@@ -1,5 +1,5 @@
 {
-    "recommended_version": "9.0.6",
+    "recommended_version": "9.0.7",
     "required_min_version": "9.0.2",
     "required_min_version_update_date": "2024-09-26",
     "required_min_version_info": {

--- a/horde_worker_regen/bridge_data/data_model.py
+++ b/horde_worker_regen/bridge_data/data_model.py
@@ -50,7 +50,7 @@ class reGenBridgeData(CombinedHordeBridgeData):
     download_timeout: int = Field(default=TOTAL_LORA_DOWNLOAD_TIMEOUT + 1)
     preload_timeout: int = Field(default=60, ge=15)
 
-    minutes_allowed_without_jobs = Field(default=30, ge=0, lt=60 * 60)
+    minutes_allowed_without_jobs: int = Field(default=30, ge=0, lt=60 * 60)
 
     horde_model_stickiness: float = Field(default=0.0, le=1.0, ge=0.0, alias="model_stickiness")
     """

--- a/horde_worker_regen/bridge_data/data_model.py
+++ b/horde_worker_regen/bridge_data/data_model.py
@@ -50,6 +50,8 @@ class reGenBridgeData(CombinedHordeBridgeData):
     download_timeout: int = Field(default=TOTAL_LORA_DOWNLOAD_TIMEOUT + 1)
     preload_timeout: int = Field(default=60, ge=15)
 
+    minutes_allowed_without_jobs = Field(default=30, ge=0, lt=60 * 60)
+
     horde_model_stickiness: float = Field(default=0.0, le=1.0, ge=0.0, alias="model_stickiness")
     """
     A percent chance (expressed as a decimal between 0 and 1) that the currently loaded models will

--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -3408,15 +3408,14 @@ class HordeWorkerProcessManager:
         info_string += f"(Skipped reasons: {job_pop_response.skipped.model_dump(exclude_defaults=True)})"
 
         if job_pop_response.id_ is None:
-            logger.info(info_string)
-            cur_time = time.time()
-            if self._last_pop_no_jobs_available_time == 0.0:
-                self._last_pop_no_jobs_available_time = cur_time
-
-            self._time_spent_no_jobs_available += cur_time - self._last_pop_no_jobs_available_time
-            self._last_pop_no_jobs_available_time = cur_time
-
             self._last_pop_no_jobs_available = True
+            logger.info(info_string)
+            if len(self.job_deque) == 0:
+                if self._last_pop_no_jobs_available_time == 0.0:
+                    self._last_pop_no_jobs_available_time = cur_time
+
+                self._time_spent_no_jobs_available += cur_time - self._last_pop_no_jobs_available_time
+                self._last_pop_no_jobs_available_time = cur_time
             return
 
         self.job_faults[job_pop_response.id_] = []

--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -4032,12 +4032,20 @@ class HordeWorkerProcessManager:
                     f"{self._too_many_consecutive_failed_jobs_wait_time} seconds must pass before resuming.",
                 )
 
-            if self._time_spent_no_jobs_available > 60 * 5:
-                logger.warning(
-                    "Your worker spent more than 5 minutes without jobs. This may be due to low demand. "
-                    "However, offering more models or increasing your max_power may help increase the number of jobs "
-                    "you receive.",
-                )
+            minutes_allowed_without_jobs = self.bridge_data.minutes_allowed_without_jobs
+            seconds_allowed_without_jobs = minutes_allowed_without_jobs * 60
+            if self._time_spent_no_jobs_available > seconds_allowed_without_jobs:
+                if not self.bridge_data.suppress_speed_warnings:
+                    logger.warning(
+                        f"Your worker spent more than {minutes_allowed_without_jobs} minutes without jobs. "
+                        "This may be due to low demand. However, offering more models or increasing your max_power "
+                        "may help increase the number of jobs you receive and reduce downtime.",
+                    )
+                else:
+                    logger.debug(
+                        "Suppressed warning about time spent without jobs "
+                        f"for {minutes_allowed_without_jobs} minutes",
+                    )
 
             if self._shutting_down:
                 logger.warning("Shutting down after current jobs are finished...")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "horde_worker_regen"
-version = "9.0.6"
+version = "9.0.7"
 description = "Allows you to connect to the AI Horde and generate images for users."
 authors = [
     {name = "tazlin", email = "tazlin.on.github@gmail.com"},


### PR DESCRIPTION
- Sets default warning time for no jobs popped to 30 minutes combined.
- Clarifies the meaning of the warning associated with this message. It now reads:
> Your worker spent more than {minutes_allowed_without_jobs} minutes combined throughout this session ({cur_session_minutes:.2f} minutes) without jobs. This may be due to low demand. However, offering more models or increasing your max_power may help increase the number of jobs you receive and reduce downtime.
- Setting `suppress_speed_warnings: true` in your config will suppress this message from appearing.