### PR TITLE
fix: use a `certifi` ssl context for r2 uploads

### DIFF
--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -8,6 +8,7 @@ import multiprocessing
 import os
 import queue
 import random
+import ssl
 import sys
 import time
 from asyncio import CancelledError, Task
@@ -22,6 +23,7 @@ from multiprocessing.synchronize import Semaphore
 
 import aiohttp
 import aiohttp.client_exceptions
+import certifi
 import PIL
 import PIL.Image
 import psutil
@@ -88,6 +90,8 @@ from horde_worker_regen.process_management.messages import (
     ModelLoadState,
 )
 from horde_worker_regen.process_management.worker_entry_points import start_inference_process, start_safety_process
+
+sslcontext = ssl.create_default_context(cafile=certifi.where())
 
 # This is due to Linux/Windows differences in the multiprocessing module
 try:
@@ -2469,6 +2473,7 @@ class HordeWorkerProcessManager:
                     data=image_in_buffer_bytes,
                     skip_auto_headers=["content-type"],
                     timeout=aiohttp.ClientTimeout(total=10),
+                    ssl=sslcontext,
                 ) as response:
                     if response.status != 200:
                         logger.error(f"Failed to upload image to R2: {response}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 numpy==1.26.4
 torch==2.3.1
-qrcode==7.4.2
+qrcode==7.4.2 # >8 breaks horde-engine 2.15.3 via the qr code generation nodes
+
+certifi # Required for SSL cert resolution
 
 horde_sdk~=0.14.11
 horde_safety~=0.2.3


### PR DESCRIPTION
This is tied to a bug of unclear root-cause but whose practical effect is that the root signing certificate was not being found on a relatively fresh windows 10 pro machine. `certifi` should already be being pulled in, but I've marked it as an explicit requirement and I anticipate that there should not be side effects on machines which were previously running fine.