### PR TITLE
Fix installed python deps

### DIFF
--- a/Dockerfiles/Dockerfile.12.1.1-22.04
+++ b/Dockerfiles/Dockerfile.12.1.1-22.04
@@ -8,14 +8,15 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     python3.11 \
     python3-pip \
-    python3-venv \
+    python3.11-dev \
+    python3.11-venv \
+    python3.11-distutils \
     libgl1 \
     git
 
 RUN git clone https://github.com/Haidra-Org/horde-worker-reGen.git && \
     cd /horde-worker-reGen && \
-    python3.11 -m pip install --upgrade pip && \
-    python3 -m venv venv && \
+    python3.11 -m venv venv && \
     . venv/bin/activate && \
     python -m pip install --upgrade pip && \
     python -m pip install -r /horde-worker-reGen/requirements.txt -U --extra-index-url https://download.pytorch.org/whl/cu124 && \

--- a/Dockerfiles/Dockerfile.12.2.2-22.04
+++ b/Dockerfiles/Dockerfile.12.2.2-22.04
@@ -8,14 +8,15 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     python3.11 \
     python3-pip \
-    python3-venv \
+    python3.11-dev \
+    python3.11-venv \
+    python3.11-distutils \
     libgl1 \
     git
 
 RUN git clone https://github.com/Haidra-Org/horde-worker-reGen.git && \
     cd /horde-worker-reGen && \
-    python3.11 -m pip install --upgrade pip && \
-    python3 -m venv venv && \
+    python3.11 -m venv venv && \
     . venv/bin/activate && \
     python -m pip install --upgrade pip && \
     python -m pip install -r /horde-worker-reGen/requirements.txt -U --extra-index-url https://download.pytorch.org/whl/cu124 && \

--- a/Dockerfiles/Dockerfile.12.3.2-22.04
+++ b/Dockerfiles/Dockerfile.12.3.2-22.04
@@ -8,14 +8,15 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     python3.11 \
     python3-pip \
-    python3-venv \
+    python3.11-dev \
+    python3.11-venv \
+    python3.11-distutils \
     libgl1 \
     git
 
 RUN git clone https://github.com/Haidra-Org/horde-worker-reGen.git && \
     cd /horde-worker-reGen && \
-    python3.11 -m pip install --upgrade pip && \
-    python3 -m venv venv && \
+    python3.11 -m venv venv && \
     . venv/bin/activate && \
     python -m pip install --upgrade pip && \
     python -m pip install -r /horde-worker-reGen/requirements.txt -U --extra-index-url https://download.pytorch.org/whl/cu124 && \

--- a/Dockerfiles/Dockerfile.12.4-22.04
+++ b/Dockerfiles/Dockerfile.12.4-22.04
@@ -8,14 +8,15 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     python3.11 \
     python3-pip \
-    python3-venv \
+    python3.11-dev \
+    python3.11-venv \
+    python3.11-distutils \
     libgl1 \
     git
 
 RUN git clone https://github.com/Haidra-Org/horde-worker-reGen.git && \
     cd /horde-worker-reGen && \
-    python3.11 -m pip install --upgrade pip && \
-    python3 -m venv venv && \
+    python3.11 -m venv venv && \
     . venv/bin/activate && \
     python -m pip install --upgrade pip && \
     python -m pip install -r /horde-worker-reGen/requirements.txt -U --extra-index-url https://download.pytorch.org/whl/cu124 && \


### PR DESCRIPTION
This was incomplete and masked by 22.04 also using 3.11 as it's Python version.
python3.11-dev is technically optional, but included because it's needed on the AMD side.
venv creation HAS to be called with the full version, otherwise the dist default is used.
pip only needs to be updated inside the venv.

This should be rather straight forward and just makes the dependencies explicit.
The current behavior won't change, but if the base python version (either of the OS, or what reGen is using)
ever changes, this version won't break. The old one would throw errors when trying to use the venv.