### PR TITLE
Dockerfile for ROCm

### DIFF
--- a/Dockerfiles/Dockerfile.rocm-6.0.2
+++ b/Dockerfiles/Dockerfile.rocm-6.0.2
@@ -1,0 +1,33 @@
+FROM rocm/rocm-terminal:6.0.2
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository ppa:deadsnakes/ppa && \
+    apt-get install -y --no-install-recommends \
+    python3.11 \
+    python3-pip \
+    python3-venv \
+    git \
+    rocm
+
+RUN git clone https://github.com/Haidra-Org/horde-worker-reGen.git && \
+    cd /horde-worker-reGen && \
+    python3.11 -m pip install --upgrade pip && \
+    python3 -m venv venv && \
+    . venv/bin/activate && \
+    python -m pip install --upgrade pip && \
+    python -m pip install -r /horde-worker-reGen/requirements.rocm.txt -U --extra-index-url https://download.pytorch.org/whl/rocm6.0 && \
+    python -m pip uninstall -y pynvml nvidia-ml-py && \
+    python -m pip cache purge
+
+RUN apt-get update && apt-get install libgl1 -y
+
+CMD cd /horde-worker-reGen && \
+    git pull && \
+    . venv/bin/activate && \
+    python -m pip install -r requirements.rocm.txt opencv-python-headless -U && \
+    python -m pip uninstall -y pynvml nvidia-ml-py && \
+    python download_models.py -e && \
+    python run_worker.py -e

--- a/Dockerfiles/Dockerfile.rocm-6.0.2
+++ b/Dockerfiles/Dockerfile.rocm-6.0.2
@@ -22,7 +22,7 @@ RUN git clone https://github.com/Haidra-Org/horde-worker-reGen.git && \
     python3.11 -m venv venv && \
     . venv/bin/activate && \
     python -m pip install --upgrade pip && \
-    python -m pip install -r /horde-worker-reGen/requirements.rocm.txt -U --extra-index-url https://download.pytorch.org/whl/rocm6.0 && \
+    python -m pip install -r /horde-worker-reGen/requirements.txt -U --extra-index-url https://download.pytorch.org/whl/rocm6.0 && \
     python -m pip install opencv-python-headless -U && \
     python -m pip uninstall -y pynvml nvidia-ml-py && \
     python -m pip cache purge
@@ -30,7 +30,7 @@ RUN git clone https://github.com/Haidra-Org/horde-worker-reGen.git && \
 CMD cd /horde-worker-reGen && \
     git pull && \
     . venv/bin/activate && \
-    python -m pip install -r requirements.rocm.txt -U && \
+    python -m pip install -r requirements.txt -U && \
     python -m pip uninstall -y pynvml nvidia-ml-py && \
     ./horde_worker_regen/amd_go_fast/install_amd_go_fast.sh && \
     python download_models.py -e && \

--- a/Dockerfiles/Dockerfile.rocm-6.0.2
+++ b/Dockerfiles/Dockerfile.rocm-6.0.2
@@ -1,5 +1,7 @@
 FROM rocm/rocm-terminal:6.0.2
 
+USER root
+WORKDIR /
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
@@ -8,15 +10,16 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     python3.11 \
     python3-pip \
-    python3-venv \
+    python3.11-dev \
+    python3.11-venv \
+    python3.11-distutils \
     libgl1 \
     git \
     rocm
 
 RUN git clone https://github.com/Haidra-Org/horde-worker-reGen.git && \
     cd /horde-worker-reGen && \
-    python3.11 -m pip install --upgrade pip && \
-    python3 -m venv venv && \
+    python3.11 -m venv venv && \
     . venv/bin/activate && \
     python -m pip install --upgrade pip && \
     python -m pip install -r /horde-worker-reGen/requirements.rocm.txt -U --extra-index-url https://download.pytorch.org/whl/rocm6.0 && \
@@ -29,5 +32,14 @@ CMD cd /horde-worker-reGen && \
     . venv/bin/activate && \
     python -m pip install -r requirements.rocm.txt -U && \
     python -m pip uninstall -y pynvml nvidia-ml-py && \
+    # wait for install_amd_go_fast.sh on first install, run it in the background on later installs
+    # go_fast can not be compiled during image build, because it is hardware dependent
+    # this is ugly, but waiting 15 min on each startup is also bad
+    if [ ! -e /first_start.mark ]; then \
+      ./horde_worker_regen/amd_go_fast/install_amd_go_fast.sh && \
+      touch /first_start.mark; \
+    else \
+      ./horde_worker_regen/amd_go_fast/install_amd_go_fast.sh & \
+    fi && \
     python download_models.py -e && \
     python run_worker.py -e

--- a/Dockerfiles/Dockerfile.rocm-6.0.2
+++ b/Dockerfiles/Dockerfile.rocm-6.0.2
@@ -32,14 +32,6 @@ CMD cd /horde-worker-reGen && \
     . venv/bin/activate && \
     python -m pip install -r requirements.rocm.txt -U && \
     python -m pip uninstall -y pynvml nvidia-ml-py && \
-    # wait for install_amd_go_fast.sh on first install, run it in the background on later installs
-    # go_fast can not be compiled during image build, because it is hardware dependent
-    # this is ugly, but waiting 15 min on each startup is also bad
-    if [ ! -e /first_start.mark ]; then \
-      ./horde_worker_regen/amd_go_fast/install_amd_go_fast.sh && \
-      touch /first_start.mark; \
-    else \
-      ./horde_worker_regen/amd_go_fast/install_amd_go_fast.sh & \
-    fi && \
+    ./horde_worker_regen/amd_go_fast/install_amd_go_fast.sh && \
     python download_models.py -e && \
     python run_worker.py -e

--- a/Dockerfiles/Dockerfile.rocm-6.0.2
+++ b/Dockerfiles/Dockerfile.rocm-6.0.2
@@ -9,6 +9,7 @@ RUN apt-get update && \
     python3.11 \
     python3-pip \
     python3-venv \
+    libgl1 \
     git \
     rocm
 
@@ -19,15 +20,14 @@ RUN git clone https://github.com/Haidra-Org/horde-worker-reGen.git && \
     . venv/bin/activate && \
     python -m pip install --upgrade pip && \
     python -m pip install -r /horde-worker-reGen/requirements.rocm.txt -U --extra-index-url https://download.pytorch.org/whl/rocm6.0 && \
+    python -m pip install opencv-python-headless -U && \
     python -m pip uninstall -y pynvml nvidia-ml-py && \
     python -m pip cache purge
-
-RUN apt-get update && apt-get install libgl1 -y
 
 CMD cd /horde-worker-reGen && \
     git pull && \
     . venv/bin/activate && \
-    python -m pip install -r requirements.rocm.txt opencv-python-headless -U && \
+    python -m pip install -r requirements.rocm.txt -U && \
     python -m pip uninstall -y pynvml nvidia-ml-py && \
     python download_models.py -e && \
     python run_worker.py -e


### PR DESCRIPTION
This is a first Draft of a usable Dockerfile for AMD ROCm cards.

Based on my testing it currently only works with the `raw-png` branch, probably due to the newer dependencies (9.0.7 on AMD is also broken with micromamba).

The flash_attn handling is also not that pretty, but I'm not sure how to improve it. Feedback is especially welcome here.

I'll also have to do some performance testing to see whether there's any negative impact, and if newer ROCm versions (6.1.2) or even potentially mismatched versions (6.0 on 6.2 or 6.1 on 6.2) improve things.

There might also STILL be some memory leaks during model load, but using Docker and venv compard to micromamba makes bisecting easier.