### PR TITLE
allow use of config file in container

### DIFF
--- a/Dockerfiles/Dockerfile.12.1.1-22.04
+++ b/Dockerfiles/Dockerfile.12.1.1-22.04
@@ -26,5 +26,5 @@ CMD cd /horde-worker-reGen && \
     git pull && \
     . venv/bin/activate && \
     python -m pip install -r requirements.txt opencv-python-headless -U && \
-    python download_models.py -e && \
-    python run_worker.py -e
+    python download_models.py $(if [ ! -e bridgeData.yaml ]; then echo -e; fi) && \
+    python run_worker.py $(if [ ! -e bridgeData.yaml ]; then echo -e; fi)

--- a/Dockerfiles/Dockerfile.12.2.2-22.04
+++ b/Dockerfiles/Dockerfile.12.2.2-22.04
@@ -26,5 +26,5 @@ CMD cd /horde-worker-reGen && \
     git pull && \
     . venv/bin/activate && \
     python -m pip install -r requirements.txt opencv-python-headless -U && \
-    python download_models.py -e && \
-    python run_worker.py -e
+    python download_models.py $(if [ ! -e bridgeData.yaml ]; then echo -e; fi) && \
+    python run_worker.py $(if [ ! -e bridgeData.yaml ]; then echo -e; fi)

--- a/Dockerfiles/Dockerfile.12.3.2-22.04
+++ b/Dockerfiles/Dockerfile.12.3.2-22.04
@@ -26,5 +26,5 @@ CMD cd /horde-worker-reGen && \
     git pull && \
     . venv/bin/activate && \
     python -m pip install -r requirements.txt opencv-python-headless -U && \
-    python download_models.py -e && \
-    python run_worker.py -e
+    python download_models.py $(if [ ! -e bridgeData.yaml ]; then echo -e; fi) && \
+    python run_worker.py $(if [ ! -e bridgeData.yaml ]; then echo -e; fi)

--- a/Dockerfiles/Dockerfile.12.4-22.04
+++ b/Dockerfiles/Dockerfile.12.4-22.04
@@ -26,5 +26,5 @@ CMD cd /horde-worker-reGen && \
     git pull && \
     . venv/bin/activate && \
     python -m pip install -r requirements.txt -U && \
-    python download_models.py -e && \
-    python run_worker.py -e
+    python download_models.py $(if [ ! -e bridgeData.yaml ]; then echo -e; fi) && \
+    python run_worker.py $(if [ ! -e bridgeData.yaml ]; then echo -e; fi)

--- a/README_advanced.md
+++ b/README_advanced.md
@@ -59,7 +59,17 @@ You can find the docker images at https://hub.docker.com/r/tazlin/horde-worker-r
 
 > **Important**: Be sure to select the correct Cuda version for your machine. **The physical host must have at least the version of Cuda installed as the image**.
 
-You should set all of the settings for the docker worker via environment variables.
+You can set all of the settings for the docker worker via environment variables.
+Alternatively it is possible to mount your existing `bridgeData.yaml` file inside the containers working directory:
+  - either append `-v ./bridgeData.yaml:/horde-worker-reGen/bridgeData.yaml:ro` to your `docker run` command
+  - or include the following in your docker compose config:
+```
+    volumes:
+      - ./bridgeData.yaml:/horde-worker-reGen/bridgeData.yaml:ro
+```
+
+It is also possible to bind mount the model directory outside the container so it isn't cleared out after every update.
+To do this just mount `./models/:/horde-worker-reGen/models/`. This has to be done with write permissions so the container can actually download the models.
 
 A typical config might include (be sure to change any settings as appropriate as these settings will not work for every machine):
 


### PR DESCRIPTION
This logic checks whether bridgeData.yaml has been mapped to it's standard location.
If it finds a file there, it uses it instead of relying on env variables.

Apart from ENV variables this is the other common way of importing dynamic configuration into a container.
It comes with the advantage of not having to recreate the container to change the config and not having to convert anything, at the expense of having two state files (compose and bridgeData) and having to do a bindmount.

This should work, but hasn't been tested extensively, thus the draft.
Depending on whether this, or the [ROCm Dockerfile](https://github.com/Haidra-Org/horde-worker-reGen/pull/311) are merged first I'll update the correct pull request to match the others status.

I should also update the documentation to reflect that this is an option.