### PR TITLE
amdsmi not found

### DIFF
--- a/update-runtime-rocm.sh
+++ b/update-runtime-rocm.sh
@@ -38,7 +38,7 @@ if [ "$hordelib" = true ]; then
  ${SCRIPT_DIR}/bin/micromamba run -r "$SCRIPT_DIR/conda" -n linux python -s -m pip install horde_engine horde_model_reference --extra-index-url https://download.pytorch.org/whl/rocm6.0
 else
  ${SCRIPT_DIR}/bin/micromamba run -r "$SCRIPT_DIR/conda" -n linux python -s -m pip install -r "$SCRIPT_DIR/requirements.rocm.txt" -U --extra-index-url https://download.pytorch.org/whl/rocm6.0
-
 fi
 
+${SCRIPT_DIR}/bin/micromamba run -r "$SCRIPT_DIR/conda" -n linux python -s -m pip uninstall -y pynvml nvidia-ml-py
 ${SCRIPT_DIR}/bin/micromamba run -r "$SCRIPT_DIR/conda" -n linux "$SCRIPT_DIR/horde_worker_regen/amd_go_fast/install_amd_go_fast.sh"


### PR DESCRIPTION
This fix is already present in the docker images I'm working on.
It appears to be a regression in torch 2.4.1 due to a conflict with `pynvml` and `nvidia-ml-py`
Reference:
https://github.com/vladmandic/automatic/issues/3181