### PR TITLE
Flash Triton

### DIFF
--- a/Dockerfiles/compose.rocm.yaml
+++ b/Dockerfiles/compose.rocm.yaml
@@ -11,6 +11,8 @@ services:
         - GIT_OWNER=Haidra-Org
     container_name: reGen
     tty: true
+    environment:
+      - FLASH_ATTENTION_USE_TRITON_ROCM=TRUE
     group_add:
       - video
     volumes:

--- a/Dockerfiles/compose.rocm.yaml
+++ b/Dockerfiles/compose.rocm.yaml
@@ -4,7 +4,7 @@ services:
       context: ./
       dockerfile: ./Dockerfile.rocm
       args:
-        - ROCM_VERSION=6.1.2
+        - ROCM_VERSION=6.2.1
         - PYTHON_VERSION=3.11
         - USE_PIP_CACHE=true
         - GIT_BRANCH=main

--- a/Dockerfiles/entrypoint.sh
+++ b/Dockerfiles/entrypoint.sh
@@ -21,6 +21,11 @@ if [ ! -z "${ROCM_VERSION_SHORT}" ]; then
     export GPU_TYPE="rocm"
     export PYTORCH_EXTRA_INDEX="https://download.pytorch.org/whl/rocm${ROCM_VERSION_SHORT}"
     export REQUIREMENTS_FILE="requirements.rocm.txt"
+
+    export "${FLASH_ATTENTION_USE_TRITON_ROCM:=TRUE}"
+    #export PYTORCH_TUNABLEOP_ENABLED=1
+    export MIOPEN_FIND_MODE="FAST"
+    #export PYTORCH_HIP_ALLOC_CONF="garbage_collection_threshold:0.8,max_split_size_mb:512,expandable_segments:True"
 elif [ ! -z "${CUDA_VERSION_SHORT}" ]; then
     # CUDA environment
     export GPU_TYPE="cuda"

--- a/Dockerfiles/setup_rocm.sh
+++ b/Dockerfiles/setup_rocm.sh
@@ -2,6 +2,4 @@
 . venv/bin/activate
 python -m pip uninstall -y pynvml nvidia-ml-py
 
-if [[ "${FLASH_ATTENTION_USE_TRITON_ROCM^^}" == "TRUE" ]]; then #this requires bash, not sh to work
-  ./horde_worker_regen/amd_go_fast/install_amd_go_fast.sh
-fi
+./horde_worker_regen/amd_go_fast/install_amd_go_fast.sh

--- a/Dockerfiles/setup_rocm.sh
+++ b/Dockerfiles/setup_rocm.sh
@@ -2,4 +2,6 @@
 . venv/bin/activate
 python -m pip uninstall -y pynvml nvidia-ml-py
 
-./horde_worker_regen/amd_go_fast/install_amd_go_fast.sh
+if [[ "${FLASH_ATTENTION_USE_TRITON_ROCM^^}" == "TRUE" ]]; then #this requires bash, not sh to work
+  ./horde_worker_regen/amd_go_fast/install_amd_go_fast.sh
+fi

--- a/horde-bridge-rocm.sh
+++ b/horde-bridge-rocm.sh
@@ -7,6 +7,7 @@ CONDA_ENV_PATH="$SCRIPT_DIR/conda/envs/linux/lib"
 
 # Use the triton backend for flash_attn
 export FLASH_ATTENTION_USE_TRITON_ROCM=TRUE
+export MIOPEN_FIND_MODE="FAST"
 
 # Add the Conda environment to LD_LIBRARY_PATH
 export LD_LIBRARY_PATH="$CONDA_ENV_PATH:$LD_LIBRARY_PATH"
@@ -46,7 +47,7 @@ fi
 
 if "$SCRIPT_DIR/runtime-rocm.sh" python -s "$SCRIPT_DIR/download_models.py"; then
     echo "Model Download OK. Starting worker..."
-    "$SCRIPT_DIR/runtime-rocm.sh" python -s "$SCRIPT_DIR/run_worker.py" --amd $*
+    "$SCRIPT_DIR/runtime-rocm.sh" python -s "$SCRIPT_DIR/run_worker.py" $*
 else
     echo "download_models.py exited with error code. Aborting"
 fi

--- a/horde-bridge-rocm.sh
+++ b/horde-bridge-rocm.sh
@@ -5,11 +5,14 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # Build the absolute path to the Conda environment
 CONDA_ENV_PATH="$SCRIPT_DIR/conda/envs/linux/lib"
 
+# Use the triton backend for flash_attn
+export FLASH_ATTENTION_USE_TRITON_ROCM=TRUE
+
 # Add the Conda environment to LD_LIBRARY_PATH
 export LD_LIBRARY_PATH="$CONDA_ENV_PATH:$LD_LIBRARY_PATH"
 
-# Set torch garbage cleanup. Amd defaults cause problems.
-export PYTORCH_HIP_ALLOC_CONF=garbage_collection_threshold:0.6,max_split_size_mb:2048
+# Set torch garbage cleanup. Amd defaults cause problems. //this was less stable than the torch 2.5.0 defaults in my testing
+#export PYTORCH_HIP_ALLOC_CONF=garbage_collection_threshold:0.6,max_split_size_mb:2048
 
 # List of directories to check
 dirs=(

--- a/horde_worker_regen/amd_go_fast/amd_go_fast.py
+++ b/horde_worker_regen/amd_go_fast/amd_go_fast.py
@@ -10,7 +10,7 @@ if "AMD" in torch.cuda.get_device_name() or "Radeon" in torch.cuda.get_device_na
         def sdpa_hijack(
             query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, scale=None, enable_gqa=False
         ):
-            if query.shape[3] <= 128 and attn_mask is None and query.dtype != torch.float32:
+            if query.shape[3] <= 256 and attn_mask is None and query.dtype != torch.float32:
                 hidden_states = flash_attn_func(
                     q=query.transpose(1, 2),
                     k=key.transpose(1, 2),

--- a/horde_worker_regen/amd_go_fast/install_amd_go_fast.sh
+++ b/horde_worker_regen/amd_go_fast/install_amd_go_fast.sh
@@ -2,6 +2,7 @@
 
 # Determine if the user has a flash attention supported card.
 SUPPORTED_CARD=$(rocminfo | grep -c -e gfx1100 -e gfx1101 -e gfx1102)
+export "${FLASH_ATTENTION_USE_TRITON_ROCM:=TRUE}"
 
 if [ "$SUPPORTED_CARD" -gt 0 ]; then
     if ! pip install -U pytest git+https://github.com/ROCm/flash-attention@micmelesse/upstream_pr_rebase; then

--- a/horde_worker_regen/amd_go_fast/install_amd_go_fast.sh
+++ b/horde_worker_regen/amd_go_fast/install_amd_go_fast.sh
@@ -4,7 +4,7 @@
 SUPPORTED_CARD=$(rocminfo | grep -c -e gfx1100 -e gfx1101 -e gfx1102)
 
 if [ "$SUPPORTED_CARD" -gt 0 ]; then
-    if ! python -s -m pip install -U git+https://github.com/ROCm/flash-attention@micmelesse/upstream_pr; then
+    if ! pip install -U pytest git+https://github.com/ROCm/flash-attention@micmelesse/upstream_pr; then
 		echo "Tried to install flash attention and failed!"
 	else
 		echo "Installed flash attn."

--- a/horde_worker_regen/amd_go_fast/install_amd_go_fast.sh
+++ b/horde_worker_regen/amd_go_fast/install_amd_go_fast.sh
@@ -4,7 +4,7 @@
 SUPPORTED_CARD=$(rocminfo | grep -c -e gfx1100 -e gfx1101 -e gfx1102)
 
 if [ "$SUPPORTED_CARD" -gt 0 ]; then
-    if ! python -s -m pip install -U git+https://github.com/ROCm/flash-attention@howiejay/navi_support; then
+    if ! python -s -m pip install -U git+https://github.com/ROCm/flash-attention@micmelesse/upstream_pr; then
 		echo "Tried to install flash attention and failed!"
 	else
 		echo "Installed flash attn."

--- a/horde_worker_regen/amd_go_fast/install_amd_go_fast.sh
+++ b/horde_worker_regen/amd_go_fast/install_amd_go_fast.sh
@@ -2,9 +2,8 @@
 
 # Determine if the user has a flash attention supported card.
 SUPPORTED_CARD=$(rocminfo | grep -c -e gfx1100 -e gfx1101 -e gfx1102)
-export "${FLASH_ATTENTION_USE_TRITON_ROCM:=TRUE}"
 
-if [ "$SUPPORTED_CARD" -gt 0 ]; then
+if [ "$SUPPORTED_CARD" -gt 0 -a "${FLASH_ATTENTION_USE_TRITON_ROCM^^}" == "TRUE" ]; then
     if ! pip install -U pytest git+https://github.com/ROCm/flash-attention@micmelesse/upstream_pr_rebase; then
 		echo "Tried to install flash attention and failed!"
 	else

--- a/horde_worker_regen/amd_go_fast/install_amd_go_fast.sh
+++ b/horde_worker_regen/amd_go_fast/install_amd_go_fast.sh
@@ -4,7 +4,7 @@
 SUPPORTED_CARD=$(rocminfo | grep -c -e gfx1100 -e gfx1101 -e gfx1102)
 
 if [ "$SUPPORTED_CARD" -gt 0 ]; then
-    if ! pip install -U pytest git+https://github.com/ROCm/flash-attention@micmelesse/upstream_pr; then
+    if ! pip install -U pytest git+https://github.com/ROCm/flash-attention@micmelesse/upstream_pr_rebase; then
 		echo "Tried to install flash attention and failed!"
 	else
 		echo "Installed flash attn."

--- a/requirements.rocm.txt
+++ b/requirements.rocm.txt
@@ -1,4 +1,4 @@
-torch==2.4.1
+torch==2.5.0
 qrcode==7.4.2 # >8 breaks horde-engine 2.17.1 via the qr code generation nodes
 
 certifi # Required for SSL cert resolution

--- a/update-runtime-rocm.sh
+++ b/update-runtime-rocm.sh
@@ -26,6 +26,7 @@ shift # past argument or value
 done
 
 CONDA_ENVIRONMENT_FILE=environment.rocm.yaml
+export FLASH_ATTENTION_USE_TRITON_ROCM=TRUE
 
 wget -qO- https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-linux-64.tar.bz2 | tar -xvj -C "${SCRIPT_DIR}"
 if [ ! -f "$SCRIPT_DIR/conda/envs/linux/bin/python" ]; then

--- a/update-runtime-rocm.sh
+++ b/update-runtime-rocm.sh
@@ -36,9 +36,9 @@ ${SCRIPT_DIR}/bin/micromamba create --no-shortcuts -r "$SCRIPT_DIR/conda" -n lin
 
 if [ "$hordelib" = true ]; then
  ${SCRIPT_DIR}/bin/micromamba run -r "$SCRIPT_DIR/conda" -n linux python -s -m pip uninstall -y hordelib horde_engine horde_sdk horde_model_reference
- ${SCRIPT_DIR}/bin/micromamba run -r "$SCRIPT_DIR/conda" -n linux python -s -m pip install horde_engine horde_model_reference --extra-index-url https://download.pytorch.org/whl/rocm6.0
+ ${SCRIPT_DIR}/bin/micromamba run -r "$SCRIPT_DIR/conda" -n linux python -s -m pip install horde_engine horde_model_reference --extra-index-url https://download.pytorch.org/whl/rocm6.2
 else
- ${SCRIPT_DIR}/bin/micromamba run -r "$SCRIPT_DIR/conda" -n linux python -s -m pip install -r "$SCRIPT_DIR/requirements.rocm.txt" -U --extra-index-url https://download.pytorch.org/whl/rocm6.0
+ ${SCRIPT_DIR}/bin/micromamba run -r "$SCRIPT_DIR/conda" -n linux python -s -m pip install -r "$SCRIPT_DIR/requirements.rocm.txt" -U --extra-index-url https://download.pytorch.org/whl/rocm6.2
 fi
 
 ${SCRIPT_DIR}/bin/micromamba run -r "$SCRIPT_DIR/conda" -n linux python -s -m pip uninstall -y pynvml nvidia-ml-py


### PR DESCRIPTION
A newer (and less janky) version of flash_attn.

A bit more testing is required around changing the PyTorch version to 2.5.0 without breaking older setups.

Potential improvements:
- Skip installing flash_attn on compatiple cards if `FLASH_ATTENTION_USE_TRITON_ROCM=FALSE` (currently it's not build on old cards no matter what, but has to be set to true to avoid errors on compatible GPUs)
- Test 256 head dimensions (should be supported), might make FLUX.1 able to use it???
- Test if Triton makes the use of flash_attn possible on older RDNA cards possible