### PR TITLE
Use SIGINT to stop the docker container

### DIFF
--- a/Dockerfiles/Dockerfile.cuda
+++ b/Dockerfiles/Dockerfile.cuda
@@ -57,4 +57,6 @@ COPY entrypoint.sh /entrypoint.sh
 COPY setup_*.sh ${APP_HOME}
 RUN chmod +x /entrypoint.sh
 
+STOPSIGNAL SIGINT
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfiles/Dockerfile.rocm
+++ b/Dockerfiles/Dockerfile.rocm
@@ -64,4 +64,6 @@ COPY entrypoint.sh /entrypoint.sh
 COPY setup_*.sh ${APP_HOME}
 RUN chmod +x /entrypoint.sh
 
+STOPSIGNAL SIGINT
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfiles/README.md
+++ b/Dockerfiles/README.md
@@ -41,7 +41,7 @@ docker start -ai reGen
 ```
 
 ### Stop
-To stop a running container (set it to maintenance mode first using a mangement site like [Artbot](https://tinybots.net/artbot/settings?panel=workers)):
+To stop a running container:
 ```bash
 docker stop reGen
 ```

--- a/Dockerfiles/README.md
+++ b/Dockerfiles/README.md
@@ -41,6 +41,9 @@ docker start -ai reGen
 ```
 
 ### Stop
+
+> Note: To reduce the chances of dropping jobs due to the `docker stop` timeout running out, please set your worker into maintenance mode first whenever possible via the [API](https://aihorde.net/api/) PUT endpoint `/v2/workers/{worker_id}` or with a frontend like [artbot.site](https://artbot.site/). 
+
 To stop a running container:
 ```bash
 docker stop reGen

--- a/Dockerfiles/compose.cuda.yaml
+++ b/Dockerfiles/compose.cuda.yaml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${AIWORKER_CACHE_HOME:-../models/}:/horde-worker-reGen/models/
       - ${AIWORKER_BRIDGE_DATA_LOCATION:-../bridgeData.yaml}:/horde-worker-reGen/bridgeData.yaml:ro
+    stop_grace_period: 60s
     deploy:
       resources:
         reservations:

--- a/Dockerfiles/compose.cuda.yaml
+++ b/Dockerfiles/compose.cuda.yaml
@@ -16,7 +16,7 @@ services:
     volumes:
       - ${AIWORKER_CACHE_HOME:-../models/}:/horde-worker-reGen/models/
       - ${AIWORKER_BRIDGE_DATA_LOCATION:-../bridgeData.yaml}:/horde-worker-reGen/bridgeData.yaml:ro
-    stop_grace_period: 60s
+    stop_grace_period: 2m
     deploy:
       resources:
         reservations:

--- a/Dockerfiles/compose.rocm.yaml
+++ b/Dockerfiles/compose.rocm.yaml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${AIWORKER_CACHE_HOME:-../models/}:/horde-worker-reGen/models/
       - ${AIWORKER_BRIDGE_DATA_LOCATION:-../bridgeData.yaml}:/horde-worker-reGen/bridgeData.yaml:ro
+    stop_grace_period: 60s
     devices:
       - /dev/kfd
       - /dev/dri

--- a/Dockerfiles/compose.rocm.yaml
+++ b/Dockerfiles/compose.rocm.yaml
@@ -16,7 +16,7 @@ services:
     volumes:
       - ${AIWORKER_CACHE_HOME:-../models/}:/horde-worker-reGen/models/
       - ${AIWORKER_BRIDGE_DATA_LOCATION:-../bridgeData.yaml}:/horde-worker-reGen/bridgeData.yaml:ro
-    stop_grace_period: 60s
+    stop_grace_period: 2m
     devices:
       - /dev/kfd
       - /dev/dri

--- a/Dockerfiles/entrypoint.sh
+++ b/Dockerfiles/entrypoint.sh
@@ -45,9 +45,9 @@ fi
 if [ -e bridgeData.yaml ]; then
     # There is a bridgeData.yaml file, we'll load from that
     python download_models.py
-    python run_worker.py
+    exec python run_worker.py
 else
     # No bridgeData.yaml file, we'll use environment variables
     python download_models.py -e
-    python run_worker.py -e
+    exec python run_worker.py -e
 fi


### PR DESCRIPTION
This should allow the `docker stop` command to shut down the python process with SIGINT, allowing the process manager to stop the processes gracefully.

```bash
$ docker compose -f Dockerfiles/compose.cuda.yaml stop
[+] Stopping 1/1
 ✔ Container reGen  Stopped 
```

```bash
reGen  | 2024-11-01 01:53:44.889 | WARNING  | horde_worker_regen.process_management.process_manager:signal_handler:4162 - Shutting down after current jobs are finished...
reGen  | 2024-11-01 01:53:47.167 | INFO     | [HWRPM]:end_safety_processes:1516 - Ended safety process 0
reGen  | 2024-11-01 01:53:47.369 | INFO     | [HWRPM]:receive_and_handle_process_messages:1579 - Process 0 has ended with message: Process ended
reGen  | 2024-11-01 01:53:47.369 | INFO     | [HWRPM]:_process_control_loop:3793 - Shutting down process manager
reGen exited with code 0
```