### PR TITLE
Fix FLASH_ATTENTION_USE_TRITON_ROCM export

### DIFF
--- a/Dockerfiles/entrypoint.sh
+++ b/Dockerfiles/entrypoint.sh
@@ -24,7 +24,7 @@ if [ ! -z "${ROCM_VERSION_SHORT}" ]; then
 
     # Determine if the user has a flash attention supported card.
     SUPPORTED_CARD=$(rocminfo | grep -c -e gfx1100 -e gfx1101 -e gfx1102)
-    if [ "$SUPPORTED_CARD" -gt 0 ]; then export "${FLASH_ATTENTION_USE_TRITON_ROCM:=TRUE}"; fi
+    if [ "$SUPPORTED_CARD" -gt 0 ]; then export FLASH_ATTENTION_USE_TRITON_ROCM="${FLASH_ATTENTION_USE_TRITON_ROCM:=TRUE}"; fi
 
     #export PYTORCH_TUNABLEOP_ENABLED=1
     export MIOPEN_FIND_MODE="FAST"

--- a/Dockerfiles/entrypoint.sh
+++ b/Dockerfiles/entrypoint.sh
@@ -22,7 +22,10 @@ if [ ! -z "${ROCM_VERSION_SHORT}" ]; then
     export PYTORCH_EXTRA_INDEX="https://download.pytorch.org/whl/rocm${ROCM_VERSION_SHORT}"
     export REQUIREMENTS_FILE="requirements.rocm.txt"
 
-    export "${FLASH_ATTENTION_USE_TRITON_ROCM:=TRUE}"
+    # Determine if the user has a flash attention supported card.
+    SUPPORTED_CARD=$(rocminfo | grep -c -e gfx1100 -e gfx1101 -e gfx1102)
+    if [ "$SUPPORTED_CARD" -gt 0 ]; then export "${FLASH_ATTENTION_USE_TRITON_ROCM:=TRUE}"; fi
+
     #export PYTORCH_TUNABLEOP_ENABLED=1
     export MIOPEN_FIND_MODE="FAST"
     #export PYTORCH_HIP_ALLOC_CONF="garbage_collection_threshold:0.8,max_split_size_mb:512,expandable_segments:True"

--- a/horde-bridge-rocm.sh
+++ b/horde-bridge-rocm.sh
@@ -7,7 +7,7 @@ CONDA_ENV_PATH="$SCRIPT_DIR/conda/envs/linux/lib"
 
 # Determine if the user has a flash attention supported card.
 SUPPORTED_CARD=$(rocminfo | grep -c -e gfx1100 -e gfx1101 -e gfx1102)
-if [ "$SUPPORTED_CARD" -gt 0 ]; then export "${FLASH_ATTENTION_USE_TRITON_ROCM:=TRUE}"; fi
+if [ "$SUPPORTED_CARD" -gt 0 ]; then export FLASH_ATTENTION_USE_TRITON_ROCM="${FLASH_ATTENTION_USE_TRITON_ROCM:=TRUE}"; fi
 export MIOPEN_FIND_MODE="FAST"
 
 # Add the Conda environment to LD_LIBRARY_PATH

--- a/horde-bridge-rocm.sh
+++ b/horde-bridge-rocm.sh
@@ -5,8 +5,9 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # Build the absolute path to the Conda environment
 CONDA_ENV_PATH="$SCRIPT_DIR/conda/envs/linux/lib"
 
-# Use the triton backend for flash_attn
-export FLASH_ATTENTION_USE_TRITON_ROCM=TRUE
+# Determine if the user has a flash attention supported card.
+SUPPORTED_CARD=$(rocminfo | grep -c -e gfx1100 -e gfx1101 -e gfx1102)
+if [ "$SUPPORTED_CARD" -gt 0 ]; then export "${FLASH_ATTENTION_USE_TRITON_ROCM:=TRUE}"; fi
 export MIOPEN_FIND_MODE="FAST"
 
 # Add the Conda environment to LD_LIBRARY_PATH

--- a/horde_worker_regen/amd_go_fast/install_amd_go_fast.sh
+++ b/horde_worker_regen/amd_go_fast/install_amd_go_fast.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
-# Determine if the user has a flash attention supported card.
-SUPPORTED_CARD=$(rocminfo | grep -c -e gfx1100 -e gfx1101 -e gfx1102)
-
-if [ "$SUPPORTED_CARD" -gt 0 -a "${FLASH_ATTENTION_USE_TRITON_ROCM^^}" == "TRUE" ]; then
+if [ "${FLASH_ATTENTION_USE_TRITON_ROCM^^}" == "TRUE" ]; then
     if ! pip install -U pytest git+https://github.com/ROCm/flash-attention@micmelesse/upstream_pr_rebase; then
 		echo "Tried to install flash attention and failed!"
 	else

--- a/update-runtime-rocm.sh
+++ b/update-runtime-rocm.sh
@@ -29,7 +29,7 @@ CONDA_ENVIRONMENT_FILE=environment.rocm.yaml
 
 # Determine if the user has a flash attention supported card.
 SUPPORTED_CARD=$(rocminfo | grep -c -e gfx1100 -e gfx1101 -e gfx1102)
-if [ "$SUPPORTED_CARD" -gt 0 ]; then export "${FLASH_ATTENTION_USE_TRITON_ROCM:=TRUE}"; fi
+if [ "$SUPPORTED_CARD" -gt 0 ]; then export FLASH_ATTENTION_USE_TRITON_ROCM="${FLASH_ATTENTION_USE_TRITON_ROCM:=TRUE}"; fi
 
 wget -qO- https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-linux-64.tar.bz2 | tar -xvj -C "${SCRIPT_DIR}"
 if [ ! -f "$SCRIPT_DIR/conda/envs/linux/bin/python" ]; then

--- a/update-runtime-rocm.sh
+++ b/update-runtime-rocm.sh
@@ -26,7 +26,10 @@ shift # past argument or value
 done
 
 CONDA_ENVIRONMENT_FILE=environment.rocm.yaml
-export FLASH_ATTENTION_USE_TRITON_ROCM=TRUE
+
+# Determine if the user has a flash attention supported card.
+SUPPORTED_CARD=$(rocminfo | grep -c -e gfx1100 -e gfx1101 -e gfx1102)
+if [ "$SUPPORTED_CARD" -gt 0 ]; then export "${FLASH_ATTENTION_USE_TRITON_ROCM:=TRUE}"; fi
 
 wget -qO- https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-linux-64.tar.bz2 | tar -xvj -C "${SCRIPT_DIR}"
 if [ ! -f "$SCRIPT_DIR/conda/envs/linux/bin/python" ]; then


### PR DESCRIPTION
This patch makes it possible to overwrite the compatibility check.
It enables flash_attn testing on older cards without having the tester dig through the code.

It also fixes a bug in the `entrypoint.sh`, that would cause flash_attn to not build on supported systems if the env variable was unset.