### PR TITLE
Mount logs directory to docker

### DIFF
--- a/Dockerfiles/compose.cuda.yaml
+++ b/Dockerfiles/compose.cuda.yaml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${AIWORKER_CACHE_HOME:-../models/}:/horde-worker-reGen/models/
       - ${AIWORKER_BRIDGE_DATA_LOCATION:-../bridgeData.yaml}:/horde-worker-reGen/bridgeData.yaml:ro
+      - ${AIWORKER_LOGS_DIR:-../logs/}:/horde-worker-reGen/logs/
     stop_grace_period: 2m
     deploy:
       resources:

--- a/Dockerfiles/compose.rocm.yaml
+++ b/Dockerfiles/compose.rocm.yaml
@@ -18,6 +18,7 @@ services:
     volumes:
       - ${AIWORKER_CACHE_HOME:-../models/}:/horde-worker-reGen/models/
       - ${AIWORKER_BRIDGE_DATA_LOCATION:-../bridgeData.yaml}:/horde-worker-reGen/bridgeData.yaml:ro
+      - ${AIWORKER_LOGS_DIR:-../logs/}:/horde-worker-reGen/logs/
     stop_grace_period: 2m
     devices:
       - /dev/kfd


### PR DESCRIPTION
This should be a useful default so that logs aren't immediately lost when for example the docker container crashes.