### PR TITLE
remove GO_FAST if support is not present

### DIFF
--- a/horde_worker_regen/amd_go_fast/install_amd_go_fast.sh
+++ b/horde_worker_regen/amd_go_fast/install_amd_go_fast.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "${FLASH_ATTENTION_USE_TRITON_ROCM^^}" == "TRUE" ]; then
-    if ! pip install -U pytest git+https://github.com/ROCm/flash-attention@micmelesse/upstream_pr_rebase; then
+	if ! pip install -U pytest git+https://github.com/ROCm/flash-attention@micmelesse/upstream_pr_rebase; then
 		echo "Tried to install flash attention and failed!"
 	else
 		echo "Installed flash attn."
@@ -11,7 +11,9 @@ if [ "${FLASH_ATTENTION_USE_TRITON_ROCM^^}" == "TRUE" ]; then
 		else
 			echo "Installed AMD GO FAST."
 		fi
-    fi
+	fi
 else
-	echo "Did not detect support for AMD GO FAST"
+	echo "Did not detect support for AMD GO FAST. Cleaning up."
+ 	pip uninstall flash_attn
+	rm "${PY_SITE_DIR}"/hordelib/nodes/amd_go_fast.py
 fi


### PR DESCRIPTION
If we want to test whether this works on new systems, it should clean up after itself if the overwride is no longer present.