### PR TITLE
enable directml

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Not only does running a worker earn you kudos, it also helps support the AI Hord
       - [Without git](#without-git)
     - [Linux](#linux)
     - [AMD](#amd)
+    - [DirectML](#directml)
   - [Basic Usage](#basic-usage)
     - [Configure](#configure)
       - [Suggested settings](#suggested-settings)
@@ -107,6 +108,10 @@ Continue with the [Basic Usage](#basic-usage) instructions
 
 If you are willing to try with your AMD card, join the [discord discussion](https://discord.com/channels/781145214752129095/1076124012305993768) in the [official discord](https://discord.gg/3DxrhksKzn).
 
+### DirectML
+
+**Experimental** Support for DirectML has beed added. See [Running on DirectML](README_advanced.md#advanced-users-running-on-directml) for more information and further instructions. You can now follow this guide using  `update-runtime-directml.cmd` and `horde-bridge-directml.cmd` where appropriate. Please note that DirectML is several times slower than *ANY* other methos of running the worker.
+
 ## Basic Usage
 
 ### Configure
@@ -185,7 +190,7 @@ The below instructions refers to `horde-bridge` or `update-runtime`. Depending o
 
 - For example, `horde-bridge.cmd` and `update-runtime.cmd` for windows with a NVIDIA card.
 - If you have an **AMD** card and you are on linux you should use `horde-bridge-rocm.sh` and `update-runtime-rocm.sh` where appropriate.
-  - All Windows AMD users should use WSL or [Docker](#docker).
+  - Windows AMD users should try to use WSL.
 
 To update:
 

--- a/README_advanced.md
+++ b/README_advanced.md
@@ -117,6 +117,26 @@ Pressing control-c will stop the worker but will first have the worker complete 
 ### Important note if manually manage your venvs
 - You should be running `python -m pip install -r requirements.txt -U https://download.pytorch.org/whl/cu124` every time you `git pull`. (Use `/whl/rocm6.2` instead if applicable)
 
+
+## Advanced users, running on directml
+
+### Caveats and Limitations:
+> DirectML is anywhere from 3x to 10x slower than other methods and will max out your VRAM at 100%. It is also not compatible with Flux.1. If you can use *ANY* other method, do that instead. Unless you have a lot of RAM, you might also run into memory issues. You should limit yourself to the smallest models and easiest jobs, even if you have a decent GPU in theory.
+
+### Prerequisites
+* Install [git](https://git-scm.com/) in your system.
+* Make sure your Windows OS and GPU drivers are up to date.
+
+### General Use:
+- The first steps are identical to the normal process: [install](README.md/#installing) and [configure](README.md/#configure) the worker. Remember to stick with the lowest end settings.
+
+- Now [update](README.md/#updating) the runtime, but make sure to use the `update-runtime-directml.cmd` script. Follow the linked instructions and run this script for future updates as well.
+
+- To run the worker again follow [starting/stopping](README.md/#startingstopping), making sure to use the `horde-bridge-directml.cmd` script.
+
+For more direct support, join the [discord discussion](https://discord.com/channels/781145214752129095/1076124012305993768) in the [official discord](https://discord.gg/3DxrhksKzn).
+
+
 ## Advanced users, container install
 
 You can find the docker images at https://hub.docker.com/r/tazlin/horde-worker-regen/tags.

--- a/download_models.py
+++ b/download_models.py
@@ -17,6 +17,12 @@ if __name__ == "__main__":
         default=False,
         help="Load the config only from environment variables. This is useful for running the worker in a container.",
     )
+    parser.add_argument(
+        "--directml",
+        type=int,
+        default=None,
+        help="Enable directml and specify device to use.",
+    )
 
     args = parser.parse_args()
 
@@ -25,4 +31,5 @@ if __name__ == "__main__":
     download_all_models(
         purge_unused_loras=args.purge_unused_loras,
         load_config_from_env_vars=args.load_config_from_env_vars,
+        directml=args.directml,
     )

--- a/horde-bridge-directml.cmd
+++ b/horde-bridge-directml.cmd
@@ -1,0 +1,35 @@
+@echo off
+cd /d %~dp0
+
+: This first call to runtime activates the environment for the rest of the script
+call runtime python -s -m pip -V
+
+call python -s -m pip uninstall hordelib
+call python -s -m pip install horde_sdk~=0.16.4 horde_model_reference~=0.9.1 horde_engine~=2.18.1 horde_safety~=0.2.3 -U
+
+if %ERRORLEVEL% NEQ 0 (
+    echo "Please run update-runtime.cmd."
+    GOTO END
+)
+
+call python -s -m pip check
+if %ERRORLEVEL% NEQ 0 (
+    echo "Please run update-runtime.cmd."
+    GOTO END
+)
+
+:DOWNLOAD
+call python -s download_models.py --directml=0
+if %ERRORLEVEL% NEQ 0 GOTO ABORT
+echo "Model Download OK. Starting worker..."
+call python -s run_worker.py --directml=0 %*
+
+GOTO END
+
+:ABORT
+echo "download_models.py exited with error code. Aborting"
+
+:END
+call micromamba deactivate >nul
+call deactivate >nul
+pause

--- a/horde_worker_regen/download_models.py
+++ b/horde_worker_regen/download_models.py
@@ -55,7 +55,7 @@ def download_all_models(
     _ = get_interrogator_no_blip()
     del _
 
-    hordelib.initialise()
+    hordelib.initialise(extra_comfyui_args="--directml")
     from hordelib.shared_model_manager import SharedModelManager
 
     SharedModelManager.load_model_managers()

--- a/horde_worker_regen/download_models.py
+++ b/horde_worker_regen/download_models.py
@@ -57,7 +57,7 @@ def download_all_models(
     del _
 
     extra_comfyui_args = []
-    if directml:
+    if directml is not None:
         extra_comfyui_args.append(f"--directml={directml}")
 
     hordelib.initialise(extra_comfyui_args=extra_comfyui_args)

--- a/horde_worker_regen/download_models.py
+++ b/horde_worker_regen/download_models.py
@@ -55,7 +55,8 @@ def download_all_models(
     _ = get_interrogator_no_blip()
     del _
 
-    hordelib.initialise(extra_comfyui_args="--directml")
+    extra_comfyui_args = ["--disable-smart-memory --directml"]
+    hordelib.initialise(extra_comfyui_args=extra_comfyui_args)
     from hordelib.shared_model_manager import SharedModelManager
 
     SharedModelManager.load_model_managers()

--- a/horde_worker_regen/download_models.py
+++ b/horde_worker_regen/download_models.py
@@ -5,7 +5,7 @@ def download_all_models(
     *,
     load_config_from_env_vars: bool = False,
     purge_unused_loras: bool = False,
-    directml: int = None,
+    directml: int | None = None,
 ) -> None:
     """Download all models specified in the config file."""
     from horde_worker_regen.load_env_vars import load_env_vars_from_config

--- a/horde_worker_regen/download_models.py
+++ b/horde_worker_regen/download_models.py
@@ -5,6 +5,7 @@ def download_all_models(
     *,
     load_config_from_env_vars: bool = False,
     purge_unused_loras: bool = False,
+    directml: int = None,
 ) -> None:
     """Download all models specified in the config file."""
     from horde_worker_regen.load_env_vars import load_env_vars_from_config
@@ -55,7 +56,10 @@ def download_all_models(
     _ = get_interrogator_no_blip()
     del _
 
-    extra_comfyui_args = ["--directml=0"]
+    extra_comfyui_args = []
+    if directml:
+        extra_comfyui_args.append(f"--directml={directml}")
+
     hordelib.initialise(extra_comfyui_args=extra_comfyui_args)
     from hordelib.shared_model_manager import SharedModelManager
 

--- a/horde_worker_regen/download_models.py
+++ b/horde_worker_regen/download_models.py
@@ -55,7 +55,7 @@ def download_all_models(
     _ = get_interrogator_no_blip()
     del _
 
-    extra_comfyui_args = ["--disable-smart-memory --directml"]
+    extra_comfyui_args = ["--directml=0"]
     hordelib.initialise(extra_comfyui_args=extra_comfyui_args)
     from hordelib.shared_model_manager import SharedModelManager
 

--- a/horde_worker_regen/process_management/main_entry_point.py
+++ b/horde_worker_regen/process_management/main_entry_point.py
@@ -12,6 +12,7 @@ def start_working(
     horde_model_reference_manager: ModelReferenceManager,
     *,
     amd_gpu: bool = False,
+    directml: int = None,
 ) -> None:
     """Create and start process manager."""
     process_manager = HordeWorkerProcessManager(
@@ -19,6 +20,7 @@ def start_working(
         bridge_data=bridge_data,
         horde_model_reference_manager=horde_model_reference_manager,
         amd_gpu=amd_gpu,
+        directml=directml,
     )
 
     process_manager.start()

--- a/horde_worker_regen/process_management/main_entry_point.py
+++ b/horde_worker_regen/process_management/main_entry_point.py
@@ -12,7 +12,7 @@ def start_working(
     horde_model_reference_manager: ModelReferenceManager,
     *,
     amd_gpu: bool = False,
-    directml: int = None,
+    directml: int | None = None,
 ) -> None:
     """Create and start process manager."""
     process_manager = HordeWorkerProcessManager(

--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -1090,7 +1090,7 @@ class HordeWorkerProcessManager:
         max_safety_processes: int = 1,
         max_download_processes: int = 1,
         amd_gpu: bool = False,
-        directml: int = None,
+        directml: int | None = None,
     ) -> None:
         """Initialise the process manager.
 

--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -1076,7 +1076,7 @@ class HordeWorkerProcessManager:
     _amd_gpu: bool
     """Whether or not the GPU is an AMD GPU."""
 
-    _directml: int
+    _directml: int | None
     """ID of the potential directml device."""
 
     def __init__(

--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -1076,6 +1076,9 @@ class HordeWorkerProcessManager:
     _amd_gpu: bool
     """Whether or not the GPU is an AMD GPU."""
 
+    _directml: int
+    """ID of the potential directml device."""
+
     def __init__(
         self,
         *,
@@ -1087,6 +1090,7 @@ class HordeWorkerProcessManager:
         max_safety_processes: int = 1,
         max_download_processes: int = 1,
         amd_gpu: bool = False,
+        directml: int = None,
     ) -> None:
         """Initialise the process manager.
 
@@ -1103,6 +1107,7 @@ class HordeWorkerProcessManager:
             max_download_processes (int, optional): The maximum number of download processes that can run at once. \
                 Defaults to 1.
             amd_gpu (bool, optional): Whether or not the GPU is an AMD GPU. Defaults to False.
+            directml (int, optional): ID of the potential directml device. Defaults to None.
         """
         self.session_start_time = time.time()
 
@@ -1124,6 +1129,7 @@ class HordeWorkerProcessManager:
         self._lru = LRUCache(self.max_inference_processes)
 
         self._amd_gpu = amd_gpu
+        self._directml = directml
 
         # If there is only one model to load and only one inference process, then we can only run one job at a time
         # and there is no point in having more than one inference process
@@ -1374,6 +1380,7 @@ class HordeWorkerProcessManager:
                 kwargs={
                     "high_memory_mode": self.bridge_data.high_memory_mode,
                     "amd_gpu": self._amd_gpu,
+                    "directml": self._directml,
                 },
             )
 
@@ -1436,6 +1443,7 @@ class HordeWorkerProcessManager:
                 "very_high_memory_mode": self.bridge_data.very_high_memory_mode,
                 "high_memory_mode": self.bridge_data.high_memory_mode,
                 "amd_gpu": self._amd_gpu,
+                "directml": self._directml,
             },
         )
         process.start()

--- a/horde_worker_regen/process_management/worker_entry_points.py
+++ b/horde_worker_regen/process_management/worker_entry_points.py
@@ -24,7 +24,7 @@ def start_inference_process(
     high_memory_mode: bool = False,
     very_high_memory_mode: bool = False,
     amd_gpu: bool = False,
-    directml: int = None,
+    directml: int | None = None,
 ) -> None:
     """Start an inference process.
 
@@ -124,7 +124,7 @@ def start_safety_process(
     *,
     high_memory_mode: bool = False,
     amd_gpu: bool = False,
-    directml: int = None,
+    directml: int | None = None,
 ) -> None:
     """Start a safety process.
 

--- a/horde_worker_regen/process_management/worker_entry_points.py
+++ b/horde_worker_regen/process_management/worker_entry_points.py
@@ -59,7 +59,7 @@ def start_inference_process(
                 f"and amd_gpu={amd_gpu}",
             )
 
-            extra_comfyui_args = ["--disable-smart-memory --directml"]
+            extra_comfyui_args = ["--disable-smart-memory", "--directml=0"]
 
             if amd_gpu:
                 extra_comfyui_args.append("--use-pytorch-cross-attention")
@@ -148,7 +148,7 @@ def start_safety_process(
 
             logger.debug(f"Initialising hordelib with process_id={process_id} and high_memory_mode={high_memory_mode}")
 
-            extra_comfyui_args = ["--disable-smart-memory --directml"]
+            extra_comfyui_args = ["--disable-smart-memory", "--directml=0"]
 
             if amd_gpu:
                 extra_comfyui_args.append("--use-pytorch-cross-attention")

--- a/horde_worker_regen/process_management/worker_entry_points.py
+++ b/horde_worker_regen/process_management/worker_entry_points.py
@@ -24,6 +24,7 @@ def start_inference_process(
     high_memory_mode: bool = False,
     very_high_memory_mode: bool = False,
     amd_gpu: bool = False,
+    directml: int = None,
 ) -> None:
     """Start an inference process.
 
@@ -59,10 +60,13 @@ def start_inference_process(
                 f"and amd_gpu={amd_gpu}",
             )
 
-            extra_comfyui_args = ["--disable-smart-memory", "--directml=0"]
+            extra_comfyui_args = ["--disable-smart-memory"]
 
             if amd_gpu:
                 extra_comfyui_args.append("--use-pytorch-cross-attention")
+
+            if directml:
+                extra_comfyui_args.append(f"--directml={directml}")
 
             models_not_to_force_load = ["flux"]
 
@@ -120,6 +124,7 @@ def start_safety_process(
     *,
     high_memory_mode: bool = False,
     amd_gpu: bool = False,
+    directml: int = None,
 ) -> None:
     """Start a safety process.
 
@@ -148,10 +153,13 @@ def start_safety_process(
 
             logger.debug(f"Initialising hordelib with process_id={process_id} and high_memory_mode={high_memory_mode}")
 
-            extra_comfyui_args = ["--disable-smart-memory", "--directml=0"]
+            extra_comfyui_args = ["--disable-smart-memory"]
 
             if amd_gpu:
                 extra_comfyui_args.append("--use-pytorch-cross-attention")
+
+            if directml:
+                extra_comfyui_args.append(f"--directml={directml}")
 
             with logger.catch(reraise=True):
                 hordelib.initialise(

--- a/horde_worker_regen/process_management/worker_entry_points.py
+++ b/horde_worker_regen/process_management/worker_entry_points.py
@@ -65,7 +65,7 @@ def start_inference_process(
             if amd_gpu:
                 extra_comfyui_args.append("--use-pytorch-cross-attention")
 
-            if directml:
+            if directml is not None:
                 extra_comfyui_args.append(f"--directml={directml}")
 
             models_not_to_force_load = ["flux"]
@@ -158,7 +158,7 @@ def start_safety_process(
             if amd_gpu:
                 extra_comfyui_args.append("--use-pytorch-cross-attention")
 
-            if directml:
+            if directml is not None:
                 extra_comfyui_args.append(f"--directml={directml}")
 
             with logger.catch(reraise=True):

--- a/horde_worker_regen/process_management/worker_entry_points.py
+++ b/horde_worker_regen/process_management/worker_entry_points.py
@@ -59,7 +59,7 @@ def start_inference_process(
                 f"and amd_gpu={amd_gpu}",
             )
 
-            extra_comfyui_args = ["--disable-smart-memory"]
+            extra_comfyui_args = ["--disable-smart-memory --directml"]
 
             if amd_gpu:
                 extra_comfyui_args.append("--use-pytorch-cross-attention")
@@ -148,7 +148,7 @@ def start_safety_process(
 
             logger.debug(f"Initialising hordelib with process_id={process_id} and high_memory_mode={high_memory_mode}")
 
-            extra_comfyui_args = ["--disable-smart-memory"]
+            extra_comfyui_args = ["--disable-smart-memory --directml"]
 
             if amd_gpu:
                 extra_comfyui_args.append("--use-pytorch-cross-attention")

--- a/horde_worker_regen/process_management/worker_entry_points.py
+++ b/horde_worker_regen/process_management/worker_entry_points.py
@@ -41,6 +41,8 @@ def start_inference_process(
             Defaults to False.
         amd_gpu (bool, optional): If true, the process will attempt to use AMD GPU-specific optimisations.
             Defaults to False.
+        directml (int | None, optional): If not None, the process will attempt to use DirectML \
+            with the specified device
     """
     with contextlib.nullcontext():  # contextlib.redirect_stdout(None), contextlib.redirect_stderr(None):
         logger.remove()
@@ -137,6 +139,8 @@ def start_safety_process(
         high_memory_mode (bool, optional): If true, the process will attempt to use more memory. Defaults to False.
         amd_gpu (bool, optional): If true, the process will attempt to use AMD GPU-specific optimisations.
             Defaults to False.
+        directml (int | None, optional): If not None, the process will attempt to use DirectML \
+            with the specified device
     """
     with contextlib.nullcontext():  # contextlib.redirect_stdout(), contextlib.redirect_stderr():
         logger.remove()

--- a/horde_worker_regen/run_worker.py
+++ b/horde_worker_regen/run_worker.py
@@ -18,7 +18,7 @@ from multiprocessing.context import BaseContext
 from loguru import logger
 
 
-def main(ctx: BaseContext, load_from_env_vars: bool = False, *, amd_gpu: bool = False) -> None:
+def main(ctx: BaseContext, load_from_env_vars: bool = False, *, amd_gpu: bool = False, directml: int = None) -> None:
     """Check for a valid config and start the driver ('main') process for the reGen worker."""
     from horde_model_reference.model_reference_manager import ModelReferenceManager
     from pydantic import ValidationError
@@ -98,6 +98,7 @@ def main(ctx: BaseContext, load_from_env_vars: bool = False, *, amd_gpu: bool = 
         bridge_data=bridge_data,
         horde_model_reference_manager=horde_model_reference_manager,
         amd_gpu=amd_gpu,
+        directml=directml,
     )
 
 
@@ -165,6 +166,12 @@ def init() -> None:
         default=None,
         help="Override the worker name from the config file, for running multiple workers on one machine",
     )
+    parser.add_argument(
+        "--directml",
+        type=int,
+        default=None,
+        help="Enable directml and specify device to use.",
+    )
 
     args = parser.parse_args()
 
@@ -206,7 +213,7 @@ def init() -> None:
 
     # We only need to download the legacy DBs once, so we do it here instead of in the worker processes
 
-    main(multiprocessing.get_context("spawn"), args.load_config_from_env_vars, amd_gpu=args.amd)
+    main(multiprocessing.get_context("spawn"), args.load_config_from_env_vars, amd_gpu=args.amd, directml=directml)
 
 
 if __name__ == "__main__":

--- a/horde_worker_regen/run_worker.py
+++ b/horde_worker_regen/run_worker.py
@@ -18,7 +18,7 @@ from multiprocessing.context import BaseContext
 from loguru import logger
 
 
-def main(ctx: BaseContext, load_from_env_vars: bool = False, *, amd_gpu: bool = False, directml: int = None) -> None:
+def main(ctx: BaseContext, load_from_env_vars: bool = False, *, amd_gpu: bool = False, directml: int | None = None) -> None:
     """Check for a valid config and start the driver ('main') process for the reGen worker."""
     from horde_model_reference.model_reference_manager import ModelReferenceManager
     from pydantic import ValidationError

--- a/horde_worker_regen/run_worker.py
+++ b/horde_worker_regen/run_worker.py
@@ -18,7 +18,13 @@ from multiprocessing.context import BaseContext
 from loguru import logger
 
 
-def main(ctx: BaseContext, load_from_env_vars: bool = False, *, amd_gpu: bool = False, directml: int | None = None,) -> None:
+def main(
+    ctx: BaseContext,
+    load_from_env_vars: bool = False,
+    *,
+    amd_gpu: bool = False,
+    directml: int | None = None,
+) -> None:
     """Check for a valid config and start the driver ('main') process for the reGen worker."""
     from horde_model_reference.model_reference_manager import ModelReferenceManager
     from pydantic import ValidationError
@@ -213,7 +219,12 @@ def init() -> None:
 
     # We only need to download the legacy DBs once, so we do it here instead of in the worker processes
 
-    main(multiprocessing.get_context("spawn"), args.load_config_from_env_vars, amd_gpu=args.amd, directml=args.directml,)
+    main(
+        multiprocessing.get_context("spawn"),
+        args.load_config_from_env_vars,
+        amd_gpu=args.amd,
+        directml=args.directml,
+    )
 
 
 if __name__ == "__main__":

--- a/horde_worker_regen/run_worker.py
+++ b/horde_worker_regen/run_worker.py
@@ -18,7 +18,7 @@ from multiprocessing.context import BaseContext
 from loguru import logger
 
 
-def main(ctx: BaseContext, load_from_env_vars: bool = False, *, amd_gpu: bool = False, directml: int | None = None) -> None:
+def main(ctx: BaseContext, load_from_env_vars: bool = False, *, amd_gpu: bool = False, directml: int | None = None,) -> None:
     """Check for a valid config and start the driver ('main') process for the reGen worker."""
     from horde_model_reference.model_reference_manager import ModelReferenceManager
     from pydantic import ValidationError
@@ -213,7 +213,7 @@ def init() -> None:
 
     # We only need to download the legacy DBs once, so we do it here instead of in the worker processes
 
-    main(multiprocessing.get_context("spawn"), args.load_config_from_env_vars, amd_gpu=args.amd, directml=directml)
+    main(multiprocessing.get_context("spawn"), args.load_config_from_env_vars, amd_gpu=args.amd, directml=args.directml,)
 
 
 if __name__ == "__main__":

--- a/requirements.directml.txt
+++ b/requirements.directml.txt
@@ -1,0 +1,24 @@
+torch-directml
+qrcode==7.4.2 # >8 breaks horde-engine 2.18.1 via the qr code generation nodes
+
+certifi # Required for SSL cert resolution
+
+horde_sdk~=0.15.1
+horde_safety~=0.2.3
+horde_engine~=2.18.1
+horde_model_reference>=0.9.1
+
+python-dotenv
+ruamel.yaml
+semver
+wheel
+
+python-Levenshtein
+
+pydantic>=2.9.2
+typing_extensions
+requests
+StrEnum
+loguru
+
+babel

--- a/requirements.directml.txt
+++ b/requirements.directml.txt
@@ -1,9 +1,9 @@
-torch-directml
+torch-directml==0.2.5.dev240914
 qrcode==7.4.2 # >8 breaks horde-engine 2.18.1 via the qr code generation nodes
 
 certifi # Required for SSL cert resolution
 
-horde_sdk~=0.15.1
+horde_sdk~=0.16.4
 horde_safety~=0.2.3
 horde_engine~=2.18.1
 horde_model_reference>=0.9.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,8 +35,10 @@ def tracked_dependencies() -> list[str]:
     return TRACKED_DEPENDENCIES
 
 
-def get_dependency_versions(requirements_file_path: str) -> dict[str, str]:
+def get_dependency_versions(requirements_file_path: str | Path) -> dict[str, str]:
     """Get the versions of horde dependencies from the given requirements file."""
+    requirements_file_path = Path(requirements_file_path)
+
     with open(requirements_file_path) as f:
         requirements = f.readlines()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ def init_hordelib() -> None:
 PRECOMMIT_FILE_PATH = Path(__file__).parent.parent / ".pre-commit-config.yaml"
 REQUIREMENTS_FILE_PATH = Path(__file__).parent.parent / "requirements.txt"
 ROCM_REQUIREMENTS_FILE_PATH = Path(__file__).parent.parent / "requirements.rocm.txt"
+DIRECTML_REQUIREMENTS_FILE_PATH = Path(__file__).parent.parent / "requirements.directml.txt"
 
 TRACKED_DEPENDENCIES = [
     "horde_sdk",
@@ -34,10 +35,9 @@ def tracked_dependencies() -> list[str]:
     return TRACKED_DEPENDENCIES
 
 
-@pytest.fixture(scope="session")
-def horde_dependency_versions() -> dict[str, str]:
-    """Get the versions of horde dependencies from the requirements file."""
-    with open(REQUIREMENTS_FILE_PATH) as f:
+def get_dependency_versions(requirements_file_path: str) -> dict[str, str]:
+    """Get the versions of horde dependencies from the given requirements file."""
+    with open(requirements_file_path) as f:
         requirements = f.readlines()
 
     dependencies = {}
@@ -58,29 +58,21 @@ def horde_dependency_versions() -> dict[str, str]:
                 dependencies[dep] = version
 
     return dependencies
+
+
+@pytest.fixture(scope="session")
+def horde_dependency_versions() -> dict[str, str]:
+    """Get the versions of horde dependencies from the requirements file."""
+    return get_dependency_versions(REQUIREMENTS_FILE_PATH)
 
 
 @pytest.fixture(scope="session")
 def rocm_horde_dependency_versions() -> dict[str, str]:
     """Get the versions of horde dependencies from the ROCm requirements file."""
-    with open(ROCM_REQUIREMENTS_FILE_PATH) as f:
-        requirements = f.readlines()
+    return get_dependency_versions(ROCM_REQUIREMENTS_FILE_PATH)
 
-    dependencies = {}
-    for req in requirements:
-        for dep in TRACKED_DEPENDENCIES:
-            if req.startswith(dep):
-                if "==" in req:
-                    version = req.split("==")[1].strip()
-                elif "~=" in req:
-                    version = req.split("~=")[1].strip()
-                elif ">=" in req:
-                    version = req.split(">=")[1].strip()
-                else:
-                    raise ValueError(f"Unsupported version pin: {req}")
 
-                # Strip any info starting from the `+` character
-                version = version.split("+")[0]
-                dependencies[dep] = version
-
-    return dependencies
+@pytest.fixture(scope="session")
+def directml_horde_dependency_versions() -> dict[str, str]:
+    """Get the versions of horde dependencies from the DirectML requirements file."""
+    return get_dependency_versions(DIRECTML_REQUIREMENTS_FILE_PATH)

--- a/update-runtime-directml.cmd
+++ b/update-runtime-directml.cmd
@@ -1,0 +1,86 @@
+@echo off
+cd /d "%~dp0"
+
+SET MAMBA_ROOT_PREFIX=%~dp0conda
+echo %MAMBA_ROOT_PREFIX%
+
+if exist "%MAMBA_ROOT_PREFIX%\condabin\micromamba.bat" (
+    echo Deleting micromamba.exe as its out of date
+    del micromamba.exe
+    if errorlevel 1 (
+        echo Error: Failed to delete micromamba.exe. Please delete it manually.
+        exit /b 1
+    )
+    echo Deleting the conda directory as its out of date
+    rmdir /s /q conda
+    if errorlevel 1 (
+        echo Error: Failed to delete the conda directory. Please delete it manually.
+        exit /b 1
+    )
+)
+
+:Check if micromamba is already installed
+if exist micromamba.exe goto Isolation
+  curl.exe -L -o micromamba.exe https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-win-64
+
+
+:Isolation
+SET CONDA_SHLVL=
+SET PYTHONNOUSERSITE=1
+SET PYTHONPATH=
+echo %MAMBA_ROOT_PREFIX%
+
+
+
+setlocal EnableDelayedExpansion
+for %%a in (%*) do (
+    if /I "%%a"=="--hordelib" (
+        set hordelib=true
+    ) else (
+        set hordelib=
+    )
+    if /I "%%a"=="--scribe" (
+        set scribe=true
+    ) else (
+        set scribe=
+    )
+)
+endlocal
+
+if defined scribe (
+  SET CONDA_ENVIRONMENT_FILE=environment_scribe.yaml
+
+) else (
+  SET CONDA_ENVIRONMENT_FILE=environment.rocm.yaml
+)
+
+Reg add "HKLM\SYSTEM\CurrentControlSet\Control\FileSystem" /v "LongPathsEnabled" /t REG_DWORD /d "1" /f 2>nul
+:We do this twice the first time to workaround a conda bug where pip is not installed correctly the first time - Henk
+IF EXIST CONDA GOTO WORKAROUND_END
+.\micromamba.exe create --no-shortcuts -r conda -n windows -f %CONDA_ENVIRONMENT_FILE% -y
+:WORKAROUND_END
+.\micromamba.exe create --no-shortcuts -r conda -n windows -f %CONDA_ENVIRONMENT_FILE% -y
+
+REM Check if hordelib argument is defined
+
+micromamba.exe shell hook -s cmd.exe %MAMBA_ROOT_PREFIX% -v
+call "%MAMBA_ROOT_PREFIX%\condabin\mamba_hook.bat"
+call "%MAMBA_ROOT_PREFIX%\condabin\mamba.bat" activate windows
+
+python -s -m pip install torch-directml torchvision==0.19.1
+
+if defined hordelib (
+  python -s -m pip uninstall -y hordelib horde_engine horde_model_reference
+  python -s -m pip install horde_engine horde_model_reference
+) else (
+  if defined scribe (
+    python -s -m pip install -r requirements-scribe.txt
+  ) else (
+    python -s -m pip install -r requirements.directml.txt
+  )
+)
+call deactivate
+
+echo If there are no errors above everything should be correctly installed (If not, try deleting the folder /conda/envs/ and try again).
+
+pause


### PR DESCRIPTION
This should broaden our compatibility, although with significantly worse performance than native libraries.

ToDo:
**Worse Performance shold be documented and advised against, before announcing this.**

The PR still needs the knobs and dials to only enable directml under certain conditions, easiest would be an eqivalent to `--amd` and then maybe another initialization script?

Or maybe think about a way to properly detect what plattform we are running on and go from there?
Having 4 different `update-runtime` scripts mostly doing the same is getting a bit out of hand...