### PR TITLE
Go fast fix minor

### DIFF
--- a/Dockerfiles/compose.rocm.yaml
+++ b/Dockerfiles/compose.rocm.yaml
@@ -11,8 +11,8 @@ services:
         - GIT_OWNER=Haidra-Org
     container_name: reGen
     tty: true
-    environment:
-      - FLASH_ATTENTION_USE_TRITON_ROCM=TRUE
+    #environment:
+    #  - FLASH_ATTENTION_USE_TRITON_ROCM=TRUE
     group_add:
       - video
     volumes:

--- a/horde-bridge-rocm.sh
+++ b/horde-bridge-rocm.sh
@@ -13,7 +13,7 @@ export MIOPEN_FIND_MODE="FAST"
 # Check if we are running in WSL2
 WSL_KERNEL=$(uname -a | grep -c -e WSL2 )
 if [ "$WSL_KERNEL" -gt 0 ]; then
-    export "${IN_WSL:=TRUE}"
+    export IN_WSL="TRUE"
     echo "WSL environment detected. Patching ROCm libhsa-runtime64.so"
     for i in $(find ./ -iname libhsa-runtime64.so); do cp /opt/rocm/lib/libhsa-runtime64.so $i; done
 fi

--- a/horde_worker_regen/amd_go_fast/install_amd_go_fast.sh
+++ b/horde_worker_regen/amd_go_fast/install_amd_go_fast.sh
@@ -15,5 +15,5 @@ if [ "${FLASH_ATTENTION_USE_TRITON_ROCM^^}" == "TRUE" ]; then
 else
 	echo "Did not detect support for AMD GO FAST. Cleaning up."
  	pip uninstall flash_attn
-	rm "${PY_SITE_DIR}"/hordelib/nodes/amd_go_fast.py
+	rm -f "${PY_SITE_DIR}"/hordelib/nodes/amd_go_fast.py
 fi

--- a/update-runtime-rocm.sh
+++ b/update-runtime-rocm.sh
@@ -49,7 +49,7 @@ ${SCRIPT_DIR}/bin/micromamba run -r "$SCRIPT_DIR/conda" -n linux python -s -m pi
 # Check if we are running in WSL2
 WSL_KERNEL=$(uname -a | grep -c -e WSL2 )
 if [ "$WSL_KERNEL" -gt 0 ]; then
-    export "${IN_WSL:=TRUE}"
+    export IN_WSL="TRUE"
     echo "WSL environment detected. Patching ROCm libhsa-runtime64.so"
     for i in $(find ./ -iname libhsa-runtime64.so); do cp /opt/rocm/lib/libhsa-runtime64.so $i; done
 fi


### PR DESCRIPTION
These are some small logical oversights after updating the compatibility check and including cleanup in case flash_attn is later removed. We don't want to manually overwrite the compatibility check in the `compose.yaml` by default.

Also, without `rm -f` Docker doesn't wanna start if `FLASH_ATTN=FALSE`, because technically an `rm` on a non existant file is an unsuccessful command.

Split out from #358, since that is more complex and requires some extra testing.