### PR TITLE
build/fix: remove unnecessary torchvision pin

### DIFF
--- a/update-runtime.cmd
+++ b/update-runtime.cmd
@@ -67,7 +67,7 @@ micromamba.exe shell hook -s cmd.exe %MAMBA_ROOT_PREFIX% -v
 call "%MAMBA_ROOT_PREFIX%\condabin\mamba_hook.bat"
 call "%MAMBA_ROOT_PREFIX%\condabin\micromamba.bat" activate windows
 
-python -s -m pip install torch==2.5.0 torchvision==0.19.1 --index-url https://download.pytorch.org/whl/cu124 -U
+python -s -m pip install torch==2.5.0 --index-url https://download.pytorch.org/whl/cu124 -U
 
 if defined hordelib (
   python -s -m pip uninstall -y hordelib horde_engine horde_model_reference


### PR DESCRIPTION
This resolves the immediate issue and should avoid this sort of mismatch in the future. If a specific torchvision pin ends up being necessary again in the future I'll deal with it more robustly then.