### PR TITLE
docs: Fix missing setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ If you are willing to try with your AMD card, join the [discord discussion](http
 
 1. Make a copy of `bridgeData_template.yaml` to `bridgeData.yaml`
 2. Edit `bridgeData.yaml` and follow the instructions within to fill in your details.
+3. Change each name (`dreamer_name`, `scribe_name`, `alchemist_name`) and try for something globally unique for each.
 
 #### Suggested settings
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ If you are willing to try with your AMD card, join the [discord discussion](http
 
 1. Make a copy of `bridgeData_template.yaml` to `bridgeData.yaml`
 2. Edit `bridgeData.yaml` and follow the instructions within to fill in your details.
-3. Change each name (`dreamer_name`, `scribe_name`, `alchemist_name`) and try for something globally unique for each.
+3. Change `dreamer_name`.
+   - This name must be unique horde wide. If you get an error about "Wrong Credentials", someone else already reserved this name.
 
 #### Suggested settings
 

--- a/bridgeData_template.yaml
+++ b/bridgeData_template.yaml
@@ -78,7 +78,7 @@ require_upfront_kudos: false
 
 # Worker name for running a Dreamer instance.
 # This must be unique across the entire horde!  Do not use the default!
-# If you get the error `Wrong credentials to submit as this worker.`, try changing this name.
+# If you get the error `Wrong credentials to submit as this worker.`, try changing this name, someone else is already using it.
 dreamer_name: "An Awesome Dreamer"
 
 # Max resolution (max pixels) supported.
@@ -287,7 +287,7 @@ exit_on_unhandled_faults: false
 
 # Worker name for running a Scribe worker.
 # This must be unique across the entire horde!  Do not use the default!
-# If you get the error `Wrong credentials to submit as this worker.`, try changing this name.
+# If you get the error `Wrong credentials to submit as this worker.`, try changing this name, someone else is already using it.
 scribe_name: "An Awesome Scribe"
 
 # KoboldAI Client API URL.
@@ -307,7 +307,7 @@ branded_model: true
 
 # Worker name for running an Alchemist worker.
 # This must be unique across the entire horde!  Do not use the default!
-# If you get the error `Wrong credentials to submit as this worker.`, try changing this name.
+# If you get the error `Wrong credentials to submit as this worker.`, try changing this name, someone else is already using it.
 alchemist_name: "An Awesome Alchemist"
 
 # Alchemy forms this worker can serve.

--- a/bridgeData_template.yaml
+++ b/bridgeData_template.yaml
@@ -77,7 +77,8 @@ require_upfront_kudos: false
 #######################################
 
 # Worker name for running a Dreamer instance.
-# This must be globally unique!  Do not use the default!
+# This must be unique across the entire horde!  Do not use the default!
+# If you get the error `Wrong credentials to submit as this worker.`, try changing this name.
 dreamer_name: "An Awesome Dreamer"
 
 # Max resolution (max pixels) supported.
@@ -285,7 +286,8 @@ exit_on_unhandled_faults: false
 #########################
 
 # Worker name for running a Scribe worker.
-# This must be globally unique!  Do not use the default!
+# This must be unique across the entire horde!  Do not use the default!
+# If you get the error `Wrong credentials to submit as this worker.`, try changing this name.
 scribe_name: "An Awesome Scribe"
 
 # KoboldAI Client API URL.
@@ -304,7 +306,8 @@ branded_model: true
 ## Alchemist (Image Interrogation and Post-Processing)
 
 # Worker name for running an Alchemist worker.
-# This must be globally unique!  Do not use the default!
+# This must be unique across the entire horde!  Do not use the default!
+# If you get the error `Wrong credentials to submit as this worker.`, try changing this name.
 alchemist_name: "An Awesome Alchemist"
 
 # Alchemy forms this worker can serve.

--- a/bridgeData_template.yaml
+++ b/bridgeData_template.yaml
@@ -285,6 +285,9 @@ exit_on_unhandled_faults: false
 ## Scribe (LLM Worker) ##
 #########################
 
+# Note: Scribe is not currently supported in reGen. This section is for future use.
+# Use https://github.com/Haidra-Org/AI-Horde-Worker to run a Scribe worker.
+
 # Worker name for running a Scribe worker.
 # This must be unique across the entire horde!  Do not use the default!
 # If you get the error `Wrong credentials to submit as this worker.`, try changing this name, someone else is already using it.
@@ -303,7 +306,12 @@ max_context_length: 1024
 # Prevents the model from being used from the shared pool but ensures no other worker can pretend to serve it.
 branded_model: true
 
-## Alchemist (Image Interrogation and Post-Processing)
+#########################
+## Alchemist (Image Interrogation and Post-Processing) 
+#########################
+
+# Note: Scribe is not currently supported in reGen. This section is for future use.
+# Use https://github.com/Haidra-Org/AI-Horde-Worker to run an Alchemist worker.
 
 # Worker name for running an Alchemist worker.
 # This must be unique across the entire horde!  Do not use the default!

--- a/bridgeData_template.yaml
+++ b/bridgeData_template.yaml
@@ -77,6 +77,7 @@ require_upfront_kudos: false
 #######################################
 
 # Worker name for running a Dreamer instance.
+# This must be globally unique!  Do not use the default!
 dreamer_name: "An Awesome Dreamer"
 
 # Max resolution (max pixels) supported.
@@ -284,6 +285,7 @@ exit_on_unhandled_faults: false
 #########################
 
 # Worker name for running a Scribe worker.
+# This must be globally unique!  Do not use the default!
 scribe_name: "An Awesome Scribe"
 
 # KoboldAI Client API URL.
@@ -302,6 +304,7 @@ branded_model: true
 ## Alchemist (Image Interrogation and Post-Processing)
 
 # Worker name for running an Alchemist worker.
+# This must be globally unique!  Do not use the default!
 alchemist_name: "An Awesome Alchemist"
 
 # Alchemy forms this worker can serve.

--- a/bridgeData_template.yaml
+++ b/bridgeData_template.yaml
@@ -307,7 +307,7 @@ max_context_length: 1024
 branded_model: true
 
 #########################
-## Alchemist (Image Interrogation and Post-Processing) 
+## Alchemist (Image Interrogation and Post-Processing)
 #########################
 
 # Note: Scribe is not currently supported in reGen. This section is for future use.

--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -3504,7 +3504,11 @@ class HordeWorkerProcessManager:
                     )
                 elif "wrong credentials" in job_pop_response.message.lower():
                     logger.warning(f"Failed to pop job (Wrong Credentials): {job_pop_response}")
-                    logger.error("Did you forget to set your worker name?")
+                    logger.error("Did you forget to set your worker name (`dreamer_name` in bridgeData.yaml)?")
+                    logger.error(
+                        "Horde Worker names must be unique horde-wide. If you haven't used this name before, "
+                        "try changing your worker name.",
+                    )
                 else:
                     logger.error(f"Failed to pop job (API Error): {job_pop_response}")
                 self._job_pop_frequency = self._error_job_pop_frequency

--- a/tests/test_sdk_models.py
+++ b/tests/test_sdk_models.py
@@ -7,7 +7,7 @@ def test_skipped_status_handles_unknown_fields() -> None:
     # printed without error.
     skipped_status = ImageGenerateJobPopSkippedStatus(
         max_pixels=100,
-        testing_field=1,
+        testing_field=1,  # type: ignore
     )
 
     assert skipped_status.max_pixels == 100


### PR DESCRIPTION
Nowhere in the README or the bridge data template did it mention that the worker names needed to be unique.  However, using the default names led to the error "Wrong credentials to submit as this worker."  I found the cause on Reddit.

This adds brief notes to both the README and the template file to try to guide people explicitly on this point.  Had these notes been present, I would not have made the mistake of keeping the defaults.