### PR TITLE
flash_attn upstream

### DIFF
--- a/Dockerfiles/compose.rocm.yaml
+++ b/Dockerfiles/compose.rocm.yaml
@@ -12,7 +12,7 @@ services:
     container_name: reGen
     tty: true
     #environment:
-    #  - FLASH_ATTENTION_USE_TRITON_ROCM=TRUE
+    #  - FLASH_ATTENTION_TRITON_AMD_ENABLE=TRUE
     group_add:
       - video
     volumes:

--- a/Dockerfiles/entrypoint.sh
+++ b/Dockerfiles/entrypoint.sh
@@ -24,7 +24,7 @@ if [ ! -z "${ROCM_VERSION_SHORT}" ]; then
 
     # Determine if the user has a flash attention supported card.
     SUPPORTED_CARD=$(rocminfo | grep -c -e gfx1100 -e gfx1101 -e gfx1102)
-    if [ "$SUPPORTED_CARD" -gt 0 ]; then export FLASH_ATTENTION_USE_TRITON_ROCM="${FLASH_ATTENTION_USE_TRITON_ROCM:=TRUE}"; fi
+    if [ "$SUPPORTED_CARD" -gt 0 ]; then export FLASH_ATTENTION_TRITON_AMD_ENABLE="${FLASH_ATTENTION_TRITON_AMD_ENABLE:=TRUE}"; fi
 
     #export PYTORCH_TUNABLEOP_ENABLED=1
     export MIOPEN_FIND_MODE="FAST"

--- a/horde-bridge-rocm.sh
+++ b/horde-bridge-rocm.sh
@@ -7,7 +7,7 @@ CONDA_ENV_PATH="$SCRIPT_DIR/conda/envs/linux/lib"
 
 # Determine if the user has a flash attention supported card.
 SUPPORTED_CARD=$(rocminfo | grep -c -e gfx1100 -e gfx1101 -e gfx1102)
-if [ "$SUPPORTED_CARD" -gt 0 ]; then export FLASH_ATTENTION_USE_TRITON_ROCM="${FLASH_ATTENTION_USE_TRITON_ROCM:=TRUE}"; fi
+if [ "$SUPPORTED_CARD" -gt 0 ]; then export FLASH_ATTENTION_TRITON_AMD_ENABLE="${FLASH_ATTENTION_TRITON_AMD_ENABLE:=TRUE}"; fi
 export MIOPEN_FIND_MODE="FAST"
 
 # Check if we are running in WSL2

--- a/horde_worker_regen/amd_go_fast/install_amd_go_fast.sh
+++ b/horde_worker_regen/amd_go_fast/install_amd_go_fast.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
+PY_SITE_DIR=$(python -c "import sysconfig; print(sysconfig.get_path('purelib'))")
 
 if [ "${FLASH_ATTENTION_TRITON_AMD_ENABLE^^}" == "TRUE" ]; then
 	if ! pip install -U pytest git+https://github.com/Dao-AILab/flash-attention; then
 		echo "Tried to install flash attention and failed!"
 	else
 		echo "Installed flash attn."
-		PY_SITE_DIR=$(python -c "import sysconfig; print(sysconfig.get_path('purelib'))")
 		if ! cp horde_worker_regen/amd_go_fast/amd_go_fast.py "${PY_SITE_DIR}"/hordelib/nodes/; then
 			echo "Failed to install AMD GO FAST."
 		else

--- a/horde_worker_regen/amd_go_fast/install_amd_go_fast.sh
+++ b/horde_worker_regen/amd_go_fast/install_amd_go_fast.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "${FLASH_ATTENTION_USE_TRITON_ROCM^^}" == "TRUE" ]; then
+if [ "${FLASH_ATTENTION_TRITON_AMD_ENABLE^^}" == "TRUE" ]; then
 	if ! pip install -U pytest git+https://github.com/Dao-AILab/flash-attention; then
 		echo "Tried to install flash attention and failed!"
 	else

--- a/horde_worker_regen/amd_go_fast/install_amd_go_fast.sh
+++ b/horde_worker_regen/amd_go_fast/install_amd_go_fast.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "${FLASH_ATTENTION_USE_TRITON_ROCM^^}" == "TRUE" ]; then
-	if ! pip install -U pytest git+https://github.com/ROCm/flash-attention@micmelesse/upstream_pr_rebase; then
+	if ! pip install -U pytest git+https://github.com/Dao-AILab/flash-attention; then
 		echo "Tried to install flash attention and failed!"
 	else
 		echo "Installed flash attn."

--- a/update-runtime-rocm.sh
+++ b/update-runtime-rocm.sh
@@ -29,7 +29,7 @@ CONDA_ENVIRONMENT_FILE=environment.rocm.yaml
 
 # Determine if the user has a flash attention supported card.
 SUPPORTED_CARD=$(rocminfo | grep -c -e gfx1100 -e gfx1101 -e gfx1102)
-if [ "$SUPPORTED_CARD" -gt 0 ]; then export FLASH_ATTENTION_USE_TRITON_ROCM="${FLASH_ATTENTION_USE_TRITON_ROCM:=TRUE}"; fi
+if [ "$SUPPORTED_CARD" -gt 0 ]; then export FLASH_ATTENTION_TRITON_AMD_ENABLE="${FLASH_ATTENTION_TRITON_AMD_ENABLE:=TRUE}"; fi
 
 wget -qO- https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-linux-64.tar.bz2 | tar -xvj -C "${SCRIPT_DIR}"
 if [ ! -f "$SCRIPT_DIR/conda/envs/linux/bin/python" ]; then


### PR DESCRIPTION
These were held up behind https://github.com/Haidra-Org/horde-worker-reGen/pull/358, but apparently broke recently.
The ENV variable was renamed, so change that and switch to the official upstream implementation while we're at it.

This should be functionally identical, except well... not broken any more.