### PR TITLE
fix: avoid crash w/ remove maint flag; fix: reserve extra vram with high vram models  

### DIFF
--- a/horde_worker_regen/__init__.py
+++ b/horde_worker_regen/__init__.py
@@ -8,7 +8,7 @@ from pathlib import Path  # noqa: E402
 
 ASSETS_FOLDER_PATH = Path(__file__).parent / "assets"
 
-__version__ = "10.0.2"
+__version__ = "10.0.4"
 
 
 import pkg_resources  # noqa: E402

--- a/horde_worker_regen/_version_meta.json
+++ b/horde_worker_regen/_version_meta.json
@@ -1,5 +1,5 @@
 {
-    "recommended_version": "10.0.2",
+    "recommended_version": "10.0.4",
     "required_min_version": "9.0.2",
     "required_min_version_update_date": "2024-09-26",
     "required_min_version_info": {

--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -1612,6 +1612,8 @@ class HordeWorkerProcessManager:
         :return:
         """
         logger.info(f"Starting inference process on PID {pid}")
+        vram_heavy_models = any(model in VRAM_HEAVY_MODELS for model in self.bridge_data.image_models_to_load)
+
         pipe_connection, child_pipe_connection = multiprocessing.Pipe(duplex=True)
         # Create a new process that will run the start_inference_process function
         process = multiprocessing.Process(
@@ -1631,6 +1633,7 @@ class HordeWorkerProcessManager:
                 "high_memory_mode": self.bridge_data.high_memory_mode,
                 "amd_gpu": self._amd_gpu,
                 "directml": self._directml,
+                "vram_heavy_models": vram_heavy_models,
             },
         )
         process.start()

--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -1352,7 +1352,11 @@ class HordeWorkerProcessManager:
 
         self.enable_performance_mode()
         if self.bridge_data.remove_maintenance_on_init:
-            self.remove_maintenance()
+            try:
+                self.remove_maintenance()
+            except Exception as e:
+                logger.warning(e)
+                logger.warning("Error trying to unset maintenance. Did this worker not exist yet?")
 
         # Get the total memory of each GPU
         import torch

--- a/horde_worker_regen/process_management/worker_entry_points.py
+++ b/horde_worker_regen/process_management/worker_entry_points.py
@@ -48,6 +48,7 @@ def start_inference_process(
             Defaults to False.
         directml (int | None, optional): If not None, the process will attempt to use DirectML \
             with the specified device
+        vram_heavy_models (bool, optional): If true, the process will attempt to reserve more VRAM. Defaults to False.
     """
     with contextlib.nullcontext():  # contextlib.redirect_stdout(None), contextlib.redirect_stderr(None):
         logger.remove()

--- a/horde_worker_regen/process_management/worker_entry_points.py
+++ b/horde_worker_regen/process_management/worker_entry_points.py
@@ -27,6 +27,7 @@ def start_inference_process(
     very_high_memory_mode: bool = False,
     amd_gpu: bool = False,
     directml: int | None = None,
+    vram_heavy_models: bool = False,
 ) -> None:
     """Start an inference process.
 
@@ -96,8 +97,16 @@ def start_inference_process(
                         "cascade",
                     ],
                 )
-            else:
+            elif not vram_heavy_models:
+                logger.info("Reserving 1.4GB VRAM.")
                 extra_comfyui_args.extend(["--reserve-vram", "1.4"])
+
+            if high_memory_mode and vram_heavy_models:
+                logger.info("High memory mode and vram heavy models are both enabled. Reserving 6GB VRAM.")
+                extra_comfyui_args.extend(["--reserve-vram", "6"])
+
+            if "--reserve-vram" not in extra_comfyui_args:
+                logger.warning("No VRAM reservation specified.")
 
             with logger.catch(reraise=True):
                 logger.debug(f"Using extra comfyui args: {extra_comfyui_args}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "horde_worker_regen"
-version = "10.0.2"
+version = "10.0.4"
 description = "Allows you to connect to the AI Horde and generate images for users."
 authors = [
     {name = "tazlin", email = "tazlin.on.github@gmail.com"},


### PR DESCRIPTION
- [fix: avoid crash w/ remove maint flag if worker didn't exist](https://github.com/Haidra-Org/horde-worker-reGen/commit/119cdc0516dbe88c5d31c4d72a595bc350b97354)
  - The worker is only registered after the first job pop. Prior to this change, if the worker operator happens to have this set when changing worker name, the worker would crash and exit on start up. As this isn't really an unrecoverable scenario (we can just skip exiting maint mode in this case), I've added a try/except to warn on whatever did happen but to continue anyway.

- [fix: reserve extra vram with high vram models](https://github.com/Haidra-Org/horde-worker-reGen/commit/e67bd8cb04df3ed27cb4296eafc59930c8f9e39d)
  - This makes it so if `high_memory_mode` is on and there are big models (flux, cascade), a total of 6gb of VRAM will be reserved (per thread) to try and limit the possibility of CUDA OOMs.