### PR TITLE
feat: torch version 2.7.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
         - python-dotenv
         - aiohttp
         - horde_safety==0.2.3
-        - torch==2.5.0
+        - torch==2.7.1
         - ruamel.yaml
         - horde_engine==2.20.12
         - horde_sdk==0.17.1

--- a/README_advanced.md
+++ b/README_advanced.md
@@ -104,7 +104,7 @@ exit
 - `git clone https://github.com/Haidra-Org/horde-worker-reGen.git`
 - `cd .\horde-worker-reGen\`
 - Install the requirements:
-  - CUDA: `pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cu124`
+  - CUDA: `pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cu126`
   - RoCM: `pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/rocm6.2`
 
 ### Run worker
@@ -115,7 +115,7 @@ exit
 Pressing control-c will stop the worker but will first have the worker complete any jobs in progress before ending. Please try and avoid hard killing it unless you are seeing many major errors. You can force kill by repeatedly pressing control+c or doing a SIGKILL.
 
 ### Important note if manually manage your venvs
-- You should be running `python -m pip install -r requirements.txt -U https://download.pytorch.org/whl/cu124` every time you `git pull`. (Use `/whl/rocm6.2` instead if applicable)
+- You should be running `python -m pip install -r requirements.txt -U https://download.pytorch.org/whl/cu126` every time you `git pull`. (Use `/whl/rocm6.2` instead if applicable)
 
 
 ## Advanced users, running on directml

--- a/horde_worker_regen/bridge_data/data_model.py
+++ b/horde_worker_regen/bridge_data/data_model.py
@@ -201,10 +201,10 @@ class reGenBridgeData(CombinedHordeBridgeData):
             )
 
         if self.high_memory_mode:
-            if self.max_threads == 1:
-                logger.warning(
-                    "High memory mode is enabled, you should consider setting max_threads to 2.",
-                )
+            # if self.max_threads == 1:
+            #     logger.warning(
+            #         "High memory mode is enabled, you should consider setting max_threads to 2.",
+            #     )
 
             if self.queue_size == 0:
                 logger.warning(

--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -1351,8 +1351,8 @@ class HordeWorkerProcessManager:
                 raise ValueError(
                     "VRAM heavy models detected. Total RAM is less than 24GB. "
                     "This is not enough RAM to run the worker."
-                    "Disable `Stable Cascade 1.0` by adding it to your `models_to_skip` or remove it from your "
-                    "`models_to_load`.",
+                    "Disable the large models by adding it to your `models_to_skip` or remove it from your "
+                    "`models_to_load`. Large models include: " + ", ".join(VRAM_HEAVY_MODELS),
                 )
 
             self.target_ram_overhead_bytes = min(self.target_ram_overhead_bytes, int(20 * 1024 * 1024 * 1024 / 2))

--- a/requirements.rocm.txt
+++ b/requirements.rocm.txt
@@ -1,4 +1,4 @@
-torch==2.5.0
+torch==2.7.1
 qrcode==7.4.2 # >8 breaks horde-engine 2.20.12 via the qr code generation nodes
 
 certifi # Required for SSL cert resolution

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch==2.5.0
+torch==2.7.1
 qrcode==7.4.2 # >8 breaks horde-engine 2.20.12 via the qr code generation nodes
 
 certifi # Required for SSL cert resolution

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ deps =
     pytest-sugar
     pytest-cov
     requests
-    -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cu124
+    -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cu126
 commands =
     pytest tests {posargs} --cov
 

--- a/update-runtime.cmd
+++ b/update-runtime.cmd
@@ -67,16 +67,16 @@ micromamba.exe shell hook -s cmd.exe %MAMBA_ROOT_PREFIX% -v
 call "%MAMBA_ROOT_PREFIX%\condabin\mamba_hook.bat"
 call "%MAMBA_ROOT_PREFIX%\condabin\micromamba.bat" activate windows
 
-python -s -m pip install torch==2.5.0 --index-url https://download.pytorch.org/whl/cu124 -U
+python -s -m pip install torch==2.7.1 --index-url https://download.pytorch.org/whl/cu126 -U
 
 if defined hordelib (
   python -s -m pip uninstall -y hordelib horde_engine horde_model_reference
-  python -s -m pip install horde_engine horde_model_reference --extra-index-url https://download.pytorch.org/whl/cu124
+  python -s -m pip install horde_engine horde_model_reference --extra-index-url https://download.pytorch.org/whl/cu126
 ) else (
   if defined scribe (
     python -s -m pip install -r requirements-scribe.txt
   ) else (
-    python -s -m pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cu124 -U
+    python -s -m pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cu126 -U
   )
 )
 call "%MAMBA_ROOT_PREFIX%\condabin\micromamba.bat" deactivate

--- a/update-runtime.sh
+++ b/update-runtime.sh
@@ -35,7 +35,7 @@ ${SCRIPT_DIR}/bin/micromamba create --no-shortcuts -r "$SCRIPT_DIR/conda" -n lin
 
 if [ "$hordelib" = true ]; then
  ${SCRIPT_DIR}/bin/micromamba run -r "$SCRIPT_DIR/conda" -n linux python -s -m pip uninstall -y hordelib horde_engine horde_sdk horde_model_reference
- ${SCRIPT_DIR}/bin/micromamba run -r "$SCRIPT_DIR/conda" -n linux python -s -m pip install horde_engine horde_model_reference --extra-index-url https://download.pytorch.org/whl/cu124
+ ${SCRIPT_DIR}/bin/micromamba run -r "$SCRIPT_DIR/conda" -n linux python -s -m pip install horde_engine horde_model_reference --extra-index-url https://download.pytorch.org/whl/cu126
 else
- ${SCRIPT_DIR}/bin/micromamba run -r "$SCRIPT_DIR/conda" -n linux python -s -m pip install -r "$SCRIPT_DIR/requirements.txt" -U --extra-index-url https://download.pytorch.org/whl/cu124
+ ${SCRIPT_DIR}/bin/micromamba run -r "$SCRIPT_DIR/conda" -n linux python -s -m pip install -r "$SCRIPT_DIR/requirements.txt" -U --extra-index-url https://download.pytorch.org/whl/cu126
 fi


### PR DESCRIPTION
- Sets default torch to 2.7.1 and cu126 in an attempt to catch up with the times.
- If a worker has less than 24gb of RAM and attempts to load a large model, they will now get a clearer error message instead of one that mentions only Cascade.