### PR TITLE
ROCm 6.3.4

### DIFF
--- a/Dockerfiles/Dockerfile.rocm
+++ b/Dockerfiles/Dockerfile.rocm
@@ -60,8 +60,8 @@ RUN --mount=type=cache,target="${PIP_CACHE_DIR}",sharing=locked,id=pip-cache \
         pip install --cache-dir="${PIP_CACHE_DIR}" opencv-python-headless -r requirements.rocm.txt -U --extra-index-url "https://download.pytorch.org/whl/rocm${ROCM_VERSION_SHORT}"; \
     else \
         pip install opencv-python-headless -r requirements.rocm.txt -U --extra-index-url "https://download.pytorch.org/whl/rocm${ROCM_VERSION_SHORT}"; \
-    fi && \
-    pip uninstall -y pynvml nvidia-ml-py
+    fi
+
 # Stage 3: Final stage
 FROM builder AS final
 

--- a/Dockerfiles/Dockerfile.rocm
+++ b/Dockerfiles/Dockerfile.rocm
@@ -1,5 +1,5 @@
 # Stage 1: Base environment setup
-ARG ROCM_VERSION=6.1.2
+ARG ROCM_VERSION=6.3.4
 FROM rocm/rocm-terminal:${ROCM_VERSION} AS base
 
 USER root

--- a/Dockerfiles/compose.rocm.yaml
+++ b/Dockerfiles/compose.rocm.yaml
@@ -4,7 +4,7 @@ services:
       context: ./
       dockerfile: ./Dockerfile.rocm
       args:
-        - ROCM_VERSION=6.2.1
+        - ROCM_VERSION=6.3.4
         - PYTHON_VERSION=3.11
         - USE_PIP_CACHE=true
         - GIT_BRANCH=main

--- a/Dockerfiles/entrypoint.sh
+++ b/Dockerfiles/entrypoint.sh
@@ -23,8 +23,9 @@ if [ ! -z "${ROCM_VERSION_SHORT}" ]; then
     export REQUIREMENTS_FILE="requirements.rocm.txt"
 
     # Determine if the user has a flash attention supported card.
-    SUPPORTED_CARD=$(rocminfo | grep -c -e gfx1100 -e gfx1101 -e gfx1102)
+    SUPPORTED_CARD=$(rocminfo | grep -c -e gfx1100 -e gfx1101 -e gfx1102 || true)
     if [ "$SUPPORTED_CARD" -gt 0 ]; then export FLASH_ATTENTION_TRITON_AMD_ENABLE="${FLASH_ATTENTION_TRITON_AMD_ENABLE:=TRUE}"; fi
+    echo "FLASH_ATTENTION_TRITON_AMD_ENABLE=$FLASH_ATTENTION_TRITON_AMD_ENABLE"
 
     #export PYTORCH_TUNABLEOP_ENABLED=1
     export MIOPEN_FIND_MODE="FAST"

--- a/Dockerfiles/setup_rocm.sh
+++ b/Dockerfiles/setup_rocm.sh
@@ -1,5 +1,4 @@
 # Uninstall NVIDIA-specific packages in ROCm environment, just in case
 . venv/bin/activate
-python -m pip uninstall -y pynvml nvidia-ml-py
 
 ./horde_worker_regen/amd_go_fast/install_amd_go_fast.sh


### PR DESCRIPTION
New ROCm version, the uninstall isn't required any more.

Also work around a potential pipefail I didn't realize was an issue because it always worked on my previous test system.

No mayor functional changes.