### PR TITLE
fix: mediapipe pin; other dependencies bump

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,8 +38,9 @@ repos:
         - loguru
         - python-dotenv
         - aiohttp
-        - horde_safety==0.2.3
-        - torch==2.7.1
+        - mediapipe==0.10.21
+        - horde_safety==0.3.0
+        - torch==2.9.1
         - ruamel.yaml
         - horde_engine==2.20.12
         - horde_sdk==0.17.1

--- a/horde-bridge-directml.cmd
+++ b/horde-bridge-directml.cmd
@@ -5,7 +5,7 @@ cd /d %~dp0
 call runtime python -s -m pip -V
 
 call python -s -m pip uninstall hordelib
-call python -s -m pip install horde_sdk~=0.17.1 horde_model_reference~=0.9.2 horde_engine~=2.20.12 horde_safety~=0.2.3 -U
+call python -s -m pip install horde_sdk~=0.17.1 horde_model_reference~=0.9.2 horde_engine~=2.20.12 horde_safety~=0.3.0 -U
 
 if %ERRORLEVEL% NEQ 0 (
     echo "Please run update-runtime.cmd."

--- a/horde-bridge.cmd
+++ b/horde-bridge.cmd
@@ -5,7 +5,7 @@ cd /d %~dp0
 call runtime python -s -m pip -V
 
 call python -s -m pip uninstall hordelib
-call python -s -m pip install horde_sdk~=0.17.1 horde_model_reference~=0.9.2 horde_engine~=2.20.12 horde_safety~=0.2.3 -U
+call python -s -m pip install horde_sdk~=0.17.1 horde_model_reference~=0.9.2 horde_engine~=2.20.12 horde_safety~=0.3.0 -U
 
 if %ERRORLEVEL% NEQ 0 (
     echo "Please run update-runtime.cmd."

--- a/horde_worker_regen/__init__.py
+++ b/horde_worker_regen/__init__.py
@@ -8,7 +8,7 @@ from pathlib import Path  # noqa: E402
 
 ASSETS_FOLDER_PATH = Path(__file__).parent / "assets"
 
-__version__ = "10.1.1"
+__version__ = "10.1.2"
 
 
 import pkg_resources  # noqa: E402

--- a/horde_worker_regen/_version_meta.json
+++ b/horde_worker_regen/_version_meta.json
@@ -1,5 +1,5 @@
 {
-    "recommended_version": "10.1.1",
+    "recommended_version": "10.1.2",
     "required_min_version": "9.0.2",
     "required_min_version_update_date": "2024-09-26",
     "required_min_version_info": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "horde_worker_regen"
-version = "10.1.1"
+version = "10.1.2"
 description = "Allows you to connect to the AI Horde and generate images for users."
 authors = [
     {name = "tazlin", email = "tazlin.on.github@gmail.com"},

--- a/requirements.directml.txt
+++ b/requirements.directml.txt
@@ -4,7 +4,7 @@ qrcode==7.4.2 # >8 breaks horde-engine 2.20.12 via the qr code generation nodes
 certifi # Required for SSL cert resolution
 
 horde_sdk~=0.17.1
-horde_safety~=0.2.3
+horde_safety~=0.3.0
 horde_engine~=2.20.12
 horde_model_reference>=0.9.2
 

--- a/requirements.rocm.txt
+++ b/requirements.rocm.txt
@@ -1,10 +1,10 @@
-torch==2.7.1
+torch==2.9.1
 qrcode==7.4.2 # >8 breaks horde-engine 2.20.12 via the qr code generation nodes
 
 certifi # Required for SSL cert resolution
 
 horde_sdk~=0.17.1
-horde_safety~=0.2.3
+horde_safety~=0.3.0
 horde_engine~=2.20.12
 horde_model_reference>=0.9.2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch==2.9.0
+torch==2.9.1
 qrcode==7.4.2 # >8 breaks horde-engine 2.20.12 via the qr code generation nodes
 mediapipe==0.10.21 # >= 0.10.30 has breaking changes for horde-engine 2.20.x
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-torch==2.7.1
+torch==2.9.0
 qrcode==7.4.2 # >8 breaks horde-engine 2.20.12 via the qr code generation nodes
 
 certifi # Required for SSL cert resolution
 
 horde_sdk~=0.17.1
-horde_safety~=0.2.3
+horde_safety~=0.3.0
 horde_engine~=2.20.12
 horde_model_reference~=0.9.2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 torch==2.9.0
 qrcode==7.4.2 # >8 breaks horde-engine 2.20.12 via the qr code generation nodes
+mediapipe==0.10.21 # >= 0.10.30 has breaking changes for horde-engine 2.20.x
 
 certifi # Required for SSL cert resolution
 

--- a/update-runtime.cmd
+++ b/update-runtime.cmd
@@ -67,7 +67,7 @@ micromamba.exe shell hook -s cmd.exe %MAMBA_ROOT_PREFIX% -v
 call "%MAMBA_ROOT_PREFIX%\condabin\mamba_hook.bat"
 call "%MAMBA_ROOT_PREFIX%\condabin\micromamba.bat" activate windows
 
-python -s -m pip install torch==2.7.1 --index-url https://download.pytorch.org/whl/cu128 -U
+python -s -m pip install torch==2.9.1 --index-url https://download.pytorch.org/whl/cu128 -U
 
 if defined hordelib (
   python -s -m pip uninstall -y hordelib horde_engine horde_model_reference


### PR DESCRIPTION
- Mediapipe >=0.10.30 has breaking changes, so new installs would fail. This resolves that problem.
- Torch has an open CVE that >=2.9.0 resolves
- horde_safety >=0.3.0 has a number of fixes, including resolving it not respecting the cache isolation correctly in all situations (the clip models ended up in ~/.cache/).