### PR TITLE
fix: remove out of date incompat. hordelib check

### DIFF
--- a/horde_worker_regen/__init__.py
+++ b/horde_worker_regen/__init__.py
@@ -9,21 +9,3 @@ from pathlib import Path  # noqa: E402
 ASSETS_FOLDER_PATH = Path(__file__).parent / "assets"
 
 __version__ = "10.1.2"
-
-
-import pkg_resources  # noqa: E402
-
-
-def check_hordelib_not_installed() -> None:
-    """Check that hordelib is not installed."""
-    try:
-        pkg_resources.get_distribution("hordelib")
-        raise RuntimeError(
-            "hordelib is installed. Please uninstall it before running this package. "
-            "`hordelib` has been renamed to `horde_engine`.",
-        )
-    except pkg_resources.DistributionNotFound:
-        pass
-
-
-check_hordelib_not_installed()


### PR DESCRIPTION
The erroring code noted in #437 (failing due to [pkg_resources no longer being exported by default](https://github.com/python/cpython/issues/95299) ) was originally to smooth over the hordelib->horde_engine rename (especially in the case of manually managed venvs) and is no longer required. 

Closes #437 