### PR TITLE
Add Intel Arc XPU backend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ You can read about [kudos](https://github.com/Haidra-Org/haidra-assets/blob/main
       - [Option 2: Without Git](#option-2-without-git)
     - [Linux](#linux)
     - [AMD GPUs](#amd-gpus)
+    - [Intel Arc / XPU](#intel-arc--xpu)
     - [DirectML](#directml)
   - [Configuration](#configuration)
     - [Basic Settings](#basic-settings)
@@ -88,6 +89,15 @@ AMD support is experimental, and **Linux-only** for now:
 - [WSL support](README_advanced.md#advanced-users-amd-rocm-inside-windows-wsl) is highly experimental.
 - Join the [AMD discussion on Discord](https://discord.com/channels/781145214752129095/1076124012305993768) if you're interested in trying.
 
+### Intel Arc / XPU
+
+Intel Arc support is available on **Linux** through PyTorch XPU:
+
+- Use `update-runtime-xpu.sh` and `horde-bridge-xpu.sh`.
+- Install the Intel GPU driver and Level Zero runtime on the host OS before running the worker.
+- If you have multiple Intel GPUs, set `ONEAPI_DEVICE_SELECTOR` before launching the worker.
+- Safety checks currently stay on the CPU on XPU, so keep `safety_on_gpu: false`.
+
 ### DirectML
 
 **Experimental** Support for DirectML has been added. See [Running on DirectML](README_advanced.md#advanced-users-running-on-directml) for more information and further instructions. You can now follow this guide using  `update-runtime-directml.cmd` and `horde-bridge-directml.cmd` where appropriate. Please note that DirectML is several times slower than *ANY* other methods of running the worker.
@@ -133,6 +143,18 @@ Tailor settings to your GPU, following these pointers:
   - max_batch: 4 # Or higher
   ```
 
+- **Intel Arc A770 (16GB, Linux/XPU)**:
+
+  ```yaml
+  - queue_size: 1
+  - safety_on_gpu: false # XPU keeps the safety stack on CPU for now
+  - moderate_performance_mode: true
+  - unload_models_from_vram_often: false
+  - max_threads: 1
+  - max_power: 40
+  - max_batch: 4
+  ```
+
 - **8-10GB VRAM** (e.g. 2080, 3060, 4060, 4060 Ti):
 
   ```yaml
@@ -176,6 +198,7 @@ Tailor settings to your GPU, following these pointers:
 1. Install the worker as described in the [Installation](#installation) section.
 2. Run `horde-bridge.cmd` (Windows) or `horde-bridge.sh` (Linux).
    - **AMD**: Use `horde-bridge-rocm` versions.
+   - **Intel Arc / XPU**: Use `horde-bridge-xpu.sh`.
 
 ### Stopping
 
@@ -208,13 +231,20 @@ CUDA_VISIBLE_DEVICES=0 ./horde-bridge.sh -n "Instance 1"
 CUDA_VISIBLE_DEVICES=1 ./horde-bridge.sh -n "Instance 2"
 ```
 
+For Intel XPU, select the visible GPU with `ONEAPI_DEVICE_SELECTOR`:
+
+```bash
+ONEAPI_DEVICE_SELECTOR=level_zero:gpu:0 ./horde-bridge-xpu.sh -n "Arc A770 #1"
+ONEAPI_DEVICE_SELECTOR=level_zero:gpu:1 ./horde-bridge-xpu.sh -n "Arc A770 #2"
+```
+
 **Warning**: High RAM (32-64GB+) is needed for multiple workers. `queue_size` and `max_threads` greatly impact RAM per worker.
 
 ## Updating
 
 The worker is constantly improving. Follow development and get update notifications in our [Discord](https://discord.gg/3DxrhksKzn).
 
-Script names below assume Windows (`.cmd`) and NVIDIA. For Linux use `.sh`, for AMD use `-rocm` versions.
+Script names below assume Windows (`.cmd`) and NVIDIA. For Linux use `.sh`, for AMD use `-rocm` versions, and for Intel Arc use `-xpu` versions.
 
 ### Updating the Worker
 
@@ -234,8 +264,9 @@ Script names below assume Windows (`.cmd`) and NVIDIA. For Linux use `.sh`, for 
 > **Warning**: Some antivirus software (e.g. Avast) may interfere with the update. If you get `CRYPT_E_NO_REVOCATION_CHECK` errors, disable antivirus, retry, then re-enable.
 
 4. Run `update-runtime` for your OS to update dependencies.
-   - Not all updates require this, but run it if unsure
-   - **Advanced users**: see [README_advanced.md](README_advanced.md) for manual options
+   - **Intel Arc / XPU**: Use `update-runtime-xpu.sh`
+    - Not all updates require this, but run it if unsure
+    - **Advanced users**: see [README_advanced.md](README_advanced.md) for manual options
 5. [Start the worker](#starting) again
 
 ## Custom Models
@@ -293,6 +324,7 @@ Check the [#local-workers Discord channel](https://discord.com/channels/78114521
 Common issues and fixes:
 
 - **Download failures**: Check disk space and internet connection.
+- **Intel Arc / XPU not detected**: Confirm the Intel GPU driver and Level Zero runtime are installed, then check that `torch.xpu.is_available()` is true inside the worker environment.
 - **Job timeouts**:
   - Remove large models (Flux, Cascade, SDXL)
   - Lower `max_power`

--- a/README_advanced.md
+++ b/README_advanced.md
@@ -139,7 +139,7 @@ HSA Agents
 
 ### Prerequisites
 * Install [git](https://git-scm.com/) in your system.
-* Install CUDA/RoCM if you haven't already.
+* Install CUDA/RoCM/Intel XPU drivers if you haven't already.
 * Install Python 3.10 or 3.11.
   * If using the official python installer **and** you do not already regularly already use python, be sure to check the box that says `Add python.exe to PATH` at the first screen.
 * We **strongly recommend** you configure at least 8gb (preferably 16gb+) of memory swap space. This recommendation applies to linux too.
@@ -159,16 +159,24 @@ HSA Agents
 - Install the requirements:
   - CUDA: `pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cu128`
   - RoCM: `pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/rocm6.2`
+  - Intel XPU: `pip install -r requirements.txt --index-url https://download.pytorch.org/whl/xpu --extra-index-url https://pypi.org/simple`
+    - Intel XPU requires the Intel GPU driver and Level Zero runtime on the host OS.
+    - If you need to pin a specific Intel GPU, set `ONEAPI_DEVICE_SELECTOR` (for example `level_zero:gpu:0`) before running the commands below.
 
 ### Run worker
 - Set your config now, copying `bridgeData_template.yaml` to `bridgeData.yaml`, being sure to set an API key and worker name at a minimum
 - `python download_models.py` (**critical - must be run first every time**)
 - `python run_worker.py` (to start working)
+- Intel XPU manual invocation:
+  - `python download_models.py --xpu`
+  - `python run_worker.py --xpu`
+  - Keep `safety_on_gpu: false`, because the current safety stack uses CPU on XPU.
 
 Pressing control-c will stop the worker but will first have the worker complete any jobs in progress before ending. Please try and avoid hard killing it unless you are seeing many major errors. You can force kill by repeatedly pressing control+c or doing a SIGKILL.
 
 ### Important note if manually manage your venvs
-- You should be running `python -m pip install -r requirements.txt -U https://download.pytorch.org/whl/cu128` every time you `git pull`. (Use `/whl/rocm6.2` instead if applicable)
+- You should be running `python -m pip install -r requirements.txt -U --extra-index-url https://download.pytorch.org/whl/cu128` every time you `git pull`.
+- Use `--extra-index-url https://download.pytorch.org/whl/rocm6.2` for RoCM or `--index-url https://download.pytorch.org/whl/xpu --extra-index-url https://pypi.org/simple` for Intel XPU.
 
 
 ## Advanced users, running on directml

--- a/download_models.py
+++ b/download_models.py
@@ -1,6 +1,7 @@
 import argparse
 
 from horde_worker_regen.download_models import download_all_models
+from horde_worker_regen.runtime_backend import HordeRuntimeBackend
 from horde_worker_regen.version_meta import do_version_check
 
 if __name__ == "__main__":
@@ -23,13 +24,34 @@ if __name__ == "__main__":
         default=None,
         help="Enable directml and specify device to use.",
     )
+    parser.add_argument(
+        "--xpu",
+        action="store_true",
+        default=False,
+        help="Enable Intel XPU support for Arc and other Intel GPUs.",
+    )
+    parser.add_argument(
+        "--oneapi-device-selector",
+        type=str,
+        default=None,
+        help="Restrict Intel XPU visibility using ONEAPI_DEVICE_SELECTOR, e.g. level_zero:gpu:0.",
+    )
 
     args = parser.parse_args()
+
+    try:
+        backend = HordeRuntimeBackend(
+            directml=args.directml,
+            xpu=args.xpu,
+            oneapi_device_selector=args.oneapi_device_selector,
+        )
+    except ValueError as e:
+        parser.error(str(e))
 
     do_version_check()
 
     download_all_models(
         purge_unused_loras=args.purge_unused_loras,
         load_config_from_env_vars=args.load_config_from_env_vars,
-        directml=args.directml,
+        backend=backend,
     )

--- a/environment.xpu.yaml
+++ b/environment.xpu.yaml
@@ -1,0 +1,9 @@
+name: ldm
+channels:
+  - conda-forge
+  - defaults
+# Minimal environment for Intel XPU. PyTorch and the rest of the stack are installed with pip.
+dependencies:
+  - git
+  - pip
+  - python==3.11

--- a/horde-bridge-xpu.sh
+++ b/horde-bridge-xpu.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Get the directory of the current script
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Build the absolute path to the Conda environment
+CONDA_ENV_PATH="$SCRIPT_DIR/conda/envs/linux/lib"
+
+# Add the Conda environment to LD_LIBRARY_PATH
+export LD_LIBRARY_PATH="$CONDA_ENV_PATH:$LD_LIBRARY_PATH"
+
+# List of directories to check
+dirs=(
+    "/usr/lib"
+    "/usr/local/lib"
+    "/lib"
+    "/lib64"
+    "/usr/lib/x86_64-linux-gnu"
+)
+
+# Check each directory
+for dir in "${dirs[@]}"; do
+    if [ -f "$dir/libjemalloc.so.2" ]; then
+        export LD_PRELOAD="$dir/libjemalloc.so.2"
+        printf "Using jemalloc from $dir\n"
+        break
+    fi
+done
+
+# If jemalloc was not found, print a warning
+if [ -z "$LD_PRELOAD" ]; then
+    printf "WARNING: jemalloc not found. You may run into memory issues! We recommend running 'sudo apt install libjemalloc2'\n"
+    read -n 1 -s -r -p "Press q to quit or any other key to continue: " key
+    if [ "$key" = "q" ]; then
+        printf "\n"
+        exit 1
+    fi
+fi
+
+XPU_ARGS=(--xpu)
+if [ -n "${ONEAPI_DEVICE_SELECTOR:-}" ]; then
+    XPU_ARGS+=("--oneapi-device-selector=${ONEAPI_DEVICE_SELECTOR}")
+    printf "Using ONEAPI_DEVICE_SELECTOR=%s\n" "$ONEAPI_DEVICE_SELECTOR"
+fi
+
+if "$SCRIPT_DIR/runtime-xpu.sh" python -s "$SCRIPT_DIR/download_models.py" "${XPU_ARGS[@]}"; then
+    echo "Model Download OK. Starting worker..."
+    "$SCRIPT_DIR/runtime-xpu.sh" python -s "$SCRIPT_DIR/run_worker.py" "${XPU_ARGS[@]}" "$@"
+else
+    echo "download_models.py exited with error code. Aborting"
+fi

--- a/horde_worker_regen/download_models.py
+++ b/horde_worker_regen/download_models.py
@@ -1,14 +1,19 @@
 """Contains the code to download all models specified in the config file. Executable as a standalone script."""
 
+from horde_worker_regen.runtime_backend import HordeRuntimeBackend
+
 
 def download_all_models(
     *,
     load_config_from_env_vars: bool = False,
     purge_unused_loras: bool = False,
-    directml: int | None = None,
+    backend: HordeRuntimeBackend | None = None,
 ) -> None:
     """Download all models specified in the config file."""
     from horde_worker_regen.load_env_vars import load_env_vars_from_config
+
+    backend = backend or HordeRuntimeBackend()
+    backend.apply_environment()
 
     if not load_config_from_env_vars:
         load_env_vars_from_config()
@@ -57,8 +62,7 @@ def download_all_models(
     del _
 
     extra_comfyui_args = []
-    if directml is not None:
-        extra_comfyui_args.append(f"--directml={directml}")
+    backend.append_comfyui_args(extra_comfyui_args)
 
     hordelib.initialise(extra_comfyui_args=extra_comfyui_args)
     from hordelib.shared_model_manager import SharedModelManager

--- a/horde_worker_regen/process_management/inference_process.py
+++ b/horde_worker_regen/process_management/inference_process.py
@@ -40,6 +40,7 @@ from horde_worker_regen.process_management.messages import (
     HordeProcessState,
     ModelLoadState,
 )
+from horde_worker_regen.runtime_backend import HordeRuntimeBackend, clear_torch_cache
 
 if TYPE_CHECKING:
     from hordelib.horde import HordeLib, ProgressReport, ResultingImageReturn
@@ -80,6 +81,7 @@ class HordeInferenceProcess(HordeProcess):
     _active_model_name: str | None = None
     """The name of the currently active model. Note that other models may be loaded in RAM or VRAM."""
     _aux_model_lock: Lock
+    _backend: HordeRuntimeBackend
 
     def __init__(
         self,
@@ -93,6 +95,7 @@ class HordeInferenceProcess(HordeProcess):
         process_launch_identifier: int,
         *,
         high_memory_mode: bool = False,
+        backend: HordeRuntimeBackend | None = None,
     ) -> None:
         """Initialise the HordeInferenceProcess.
 
@@ -119,6 +122,7 @@ class HordeInferenceProcess(HordeProcess):
         )
 
         self._aux_model_lock = aux_model_lock
+        self._backend = backend or HordeRuntimeBackend()
 
         # We import these here to guard against potentially importing them in the main process
         # which would create shared objects, potentially causing issues
@@ -548,13 +552,10 @@ class HordeInferenceProcess(HordeProcess):
                 self._vae_decode_semaphore.release()
         return results
 
-    @staticmethod
-    def clear_gc_and_torch_cache() -> None:
+    def clear_gc_and_torch_cache(self) -> None:
         """Clear the garbage collector and the PyTorch cache."""
         gc.collect()
-        from torch.cuda import empty_cache
-
-        empty_cache()
+        clear_torch_cache(self._backend)
 
     @logger.catch(reraise=True)
     def unload_models_from_vram(self) -> None:

--- a/horde_worker_regen/process_management/main_entry_point.py
+++ b/horde_worker_regen/process_management/main_entry_point.py
@@ -4,6 +4,7 @@ from horde_model_reference.model_reference_manager import ModelReferenceManager
 
 from horde_worker_regen.bridge_data.data_model import reGenBridgeData
 from horde_worker_regen.process_management.process_manager import HordeWorkerProcessManager
+from horde_worker_regen.runtime_backend import HordeRuntimeBackend
 
 
 def start_working(
@@ -11,16 +12,14 @@ def start_working(
     bridge_data: reGenBridgeData,
     horde_model_reference_manager: ModelReferenceManager,
     *,
-    amd_gpu: bool = False,
-    directml: int | None = None,
+    backend: HordeRuntimeBackend | None = None,
 ) -> None:
     """Create and start process manager."""
     process_manager = HordeWorkerProcessManager(
         ctx=ctx,
         bridge_data=bridge_data,
         horde_model_reference_manager=horde_model_reference_manager,
-        amd_gpu=amd_gpu,
-        directml=directml,
+        backend=backend,
     )
 
     process_manager.start()

--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -90,6 +90,7 @@ from horde_worker_regen.process_management.messages import (
     ModelLoadState,
 )
 from horde_worker_regen.process_management.worker_entry_points import start_inference_process, start_safety_process
+from horde_worker_regen.runtime_backend import HordeRuntimeBackend, get_torch_device_infos
 
 sslcontext = ssl.create_default_context(cafile=certifi.where())
 
@@ -1239,11 +1240,8 @@ class HordeWorkerProcessManager:
     _lru: LRUCache
     """A simple LRU cache. This is used to keep track of the most recently used models."""
 
-    _amd_gpu: bool
-    """Whether or not the GPU is an AMD GPU."""
-
-    _directml: int | None
-    """ID of the potential directml device."""
+    _backend: HordeRuntimeBackend
+    """The backend configuration for worker child processes."""
 
     _api_messages_received: dict[str, APIWorkerMessage]
 
@@ -1264,8 +1262,7 @@ class HordeWorkerProcessManager:
         target_vram_overhead_bytes_map: Mapping[int, int] | None = None,  # FIXME
         max_safety_processes: int = 1,
         max_download_processes: int = 1,
-        amd_gpu: bool = False,
-        directml: int | None = None,
+        backend: HordeRuntimeBackend | None = None,
     ) -> None:
         """Initialise the process manager.
 
@@ -1281,8 +1278,7 @@ class HordeWorkerProcessManager:
                 Defaults to 1.
             max_download_processes (int, optional): The maximum number of download processes that can run at once. \
                 Defaults to 1.
-            amd_gpu (bool, optional): Whether or not the GPU is an AMD GPU. Defaults to False.
-            directml (int, optional): ID of the potential directml device. Defaults to None.
+            backend (HordeRuntimeBackend | None, optional): The backend configuration for this worker.
         """
         self.session_start_time = time.time()
 
@@ -1314,8 +1310,8 @@ class HordeWorkerProcessManager:
 
         self._lru = LRUCache(self.max_inference_processes)
 
-        self._amd_gpu = amd_gpu
-        self._directml = directml
+        self._backend = backend or HordeRuntimeBackend()
+        self._backend.apply_environment()
 
         self._replaced_due_to_maintenance = False
 
@@ -1376,16 +1372,12 @@ class HordeWorkerProcessManager:
                 logger.warning(e)
                 logger.warning("Error trying to unset maintenance. Did this worker not exist yet?")
 
-        # Get the total memory of each GPU
-        import torch
-
         self._device_map = TorchDeviceMap(root={})
-        for i in range(torch.cuda.device_count()):
-            device = torch.cuda.get_device_properties(i)
-            self._device_map.root[i] = TorchDeviceInfo(
-                device_name=device.name,
-                device_index=i,
-                total_memory=device.total_memory,
+        for device_name, device_index, total_memory in get_torch_device_infos(self._backend):
+            self._device_map.root[device_index] = TorchDeviceInfo(
+                device_name=device_name,
+                device_index=device_index,
+                total_memory=total_memory,
             )
 
         self.jobs_in_progress = []
@@ -1451,7 +1443,7 @@ class HordeWorkerProcessManager:
         if self.bridge_data.high_performance_mode:
             self._max_pending_megapixelsteps = 80
             logger.info("High performance mode enabled")
-            if not self.bridge_data.safety_on_gpu:
+            if not self.bridge_data.safety_on_gpu and self._backend.supports_gpu_safety:
                 logger.warning(
                     "If you have a high-end GPU, you should enable safety on GPU (safety_on_gpu in the config).",
                 )
@@ -1558,12 +1550,18 @@ class HordeWorkerProcessManager:
 
         # Start the required number of processes
 
+        if self.bridge_data.safety_on_gpu and not self._backend.supports_gpu_safety:
+            logger.warning(
+                f"safety_on_gpu is enabled, but the {self._backend.name} backend does not support "
+                "GPU safety reliably. Using CPU for safety checks.",
+            )
+
         for _ in range(num_processes_to_start):
             # Create a two-way communication pipe for the parent and child processes
             pid = self._process_map.num_safety_processes()
             pipe_connection, child_pipe_connection = multiprocessing.Pipe(duplex=True)
 
-            cpu_only = not self.bridge_data.safety_on_gpu
+            cpu_only = not self.bridge_data.safety_on_gpu or not self._backend.supports_gpu_safety
 
             # Create a new process that will run the start_safety_process function
             process = multiprocessing.Process(
@@ -1578,8 +1576,7 @@ class HordeWorkerProcessManager:
                 ),
                 kwargs={
                     "high_memory_mode": self.bridge_data.high_memory_mode,
-                    "amd_gpu": self._amd_gpu,
-                    "directml": self._directml,
+                    "backend": self._backend,
                 },
             )
 
@@ -1651,8 +1648,7 @@ class HordeWorkerProcessManager:
             kwargs={
                 "very_high_memory_mode": self.bridge_data.very_high_memory_mode,
                 "high_memory_mode": self.bridge_data.high_memory_mode,
-                "amd_gpu": self._amd_gpu,
-                "directml": self._directml,
+                "backend": self._backend,
                 "vram_heavy_models": vram_heavy_models,
             },
         )

--- a/horde_worker_regen/process_management/worker_entry_points.py
+++ b/horde_worker_regen/process_management/worker_entry_points.py
@@ -10,6 +10,7 @@ from multiprocessing.synchronize import Lock, Semaphore
 from loguru import logger
 
 from horde_worker_regen.process_management._aliased_types import ProcessQueue
+from horde_worker_regen.runtime_backend import HordeRuntimeBackend
 
 
 def start_inference_process(
@@ -25,8 +26,7 @@ def start_inference_process(
     low_memory_mode: bool = False,
     high_memory_mode: bool = False,
     very_high_memory_mode: bool = False,
-    amd_gpu: bool = False,
-    directml: int | None = None,
+    backend: HordeRuntimeBackend | None = None,
     vram_heavy_models: bool = False,
 ) -> None:
     """Start an inference process.
@@ -44,14 +44,13 @@ def start_inference_process(
         high_memory_mode (bool, optional): If true, the process will attempt to use more memory. Defaults to False.
         very_high_memory_mode (bool, optional): If true, the process will attempt to use even more memory.
             Defaults to False.
-        amd_gpu (bool, optional): If true, the process will attempt to use AMD GPU-specific optimisations.
-            Defaults to False.
-        directml (int | None, optional): If not None, the process will attempt to use DirectML \
-            with the specified device
+        backend (HordeRuntimeBackend | None, optional): The backend configuration for this worker process.
         vram_heavy_models (bool, optional): If true, the process will attempt to reserve more VRAM. Defaults to False.
     """
     with contextlib.nullcontext():  # contextlib.redirect_stdout(None), contextlib.redirect_stderr(None):
         logger.remove()
+        backend = backend or HordeRuntimeBackend()
+        backend.apply_environment()
 
         try:
             import hordelib
@@ -67,17 +66,12 @@ def start_inference_process(
                 f"Initialising hordelib with process_id={process_id}, "
                 f"process_launch_identifier={process_launch_identifier}, "
                 f"high_memory_mode={high_memory_mode} "
-                f"and amd_gpu={amd_gpu}, low_memory_mode={low_memory_mode}, "
+                f"and backend={backend.name}, low_memory_mode={low_memory_mode}, "
                 f"very_high_memory_mode={very_high_memory_mode}",
             )
 
             extra_comfyui_args = ["--disable-smart-memory"]
-
-            if amd_gpu:
-                extra_comfyui_args.append("--use-pytorch-cross-attention")
-
-            if directml is not None:
-                extra_comfyui_args.append(f"--directml={directml}")
+            backend.append_comfyui_args(extra_comfyui_args)
 
             models_not_to_force_load = ["flux"]
 
@@ -135,6 +129,7 @@ def start_inference_process(
             aux_model_lock=aux_model_lock,
             vae_decode_semaphore=vae_decode_semaphore,
             process_launch_identifier=process_launch_identifier,
+            backend=backend,
         )
 
         worker_process.main_loop()
@@ -149,8 +144,7 @@ def start_safety_process(
     cpu_only: bool = True,
     *,
     high_memory_mode: bool = False,
-    amd_gpu: bool = False,
-    directml: int | None = None,
+    backend: HordeRuntimeBackend | None = None,
 ) -> None:
     """Start a safety process.
 
@@ -162,13 +156,11 @@ def start_safety_process(
         process_launch_identifier (int): The unique identifier for this launch.
         cpu_only (bool, optional): If true, the process will not use the GPU. Defaults to True.
         high_memory_mode (bool, optional): If true, the process will attempt to use more memory. Defaults to False.
-        amd_gpu (bool, optional): If true, the process will attempt to use AMD GPU-specific optimizations.
-            Defaults to False.
-        directml (int | None, optional): If not None, the process will attempt to use DirectML \
-            with the specified device
+        backend (HordeRuntimeBackend | None, optional): The backend configuration for this worker process.
     """
     with contextlib.nullcontext():  # contextlib.redirect_stdout(), contextlib.redirect_stderr():
         logger.remove()
+        backend = backend or HordeRuntimeBackend()
 
         try:
             from hordelib.utils.logger import HordeLog
@@ -179,15 +171,10 @@ def start_safety_process(
                 verbosity_count=5,  # FIXME
             )
 
-            logger.debug(f"Initialising hordelib with process_id={process_id} and high_memory_mode={high_memory_mode}")
-
-            extra_comfyui_args = ["--disable-smart-memory"]
-
-            if amd_gpu:
-                extra_comfyui_args.append("--use-pytorch-cross-attention")
-
-            if directml is not None:
-                extra_comfyui_args.append(f"--directml={directml}")
+            logger.debug(
+                f"Initialising safety process with process_id={process_id}, "
+                f"high_memory_mode={high_memory_mode}, backend={backend.name}",
+            )
 
         except Exception as e:
             logger.critical(f"Failed to initialise: {type(e).__name__} {e}")
@@ -199,7 +186,7 @@ def start_safety_process(
             f"Initialising hordelib with process_id={process_id}, "
             f"process_launch_identifier={process_launch_identifier}, "
             f"cpu_only={cpu_only}, high_memory_mode={high_memory_mode} "
-            f"and amd_gpu={amd_gpu}",
+            f"and backend={backend.name}",
         )
         worker_process = HordeSafetyProcess(
             process_id=process_id,

--- a/horde_worker_regen/run_worker.py
+++ b/horde_worker_regen/run_worker.py
@@ -18,13 +18,14 @@ from multiprocessing.context import BaseContext
 import regex as re
 from loguru import logger
 
+from horde_worker_regen.runtime_backend import HordeRuntimeBackend
+
 
 def main(
     ctx: BaseContext,
     load_from_env_vars: bool = False,
     *,
-    amd_gpu: bool = False,
-    directml: int | None = None,
+    backend: HordeRuntimeBackend | None = None,
 ) -> None:
     """Check for a valid config and start the driver ('main') process for the reGen worker."""
     from horde_model_reference.model_reference_manager import ModelReferenceManager
@@ -33,6 +34,9 @@ def main(
     from horde_worker_regen.bridge_data.load_config import BridgeDataLoader, reGenBridgeData
     from horde_worker_regen.consts import BRIDGE_CONFIG_FILENAME
     from horde_worker_regen.process_management.main_entry_point import start_working
+
+    backend = backend or HordeRuntimeBackend()
+    backend.apply_environment()
 
     def ensure_model_db_downloaded() -> ModelReferenceManager:
         horde_model_reference_manager = ModelReferenceManager(
@@ -103,8 +107,7 @@ def main(
         ctx=ctx,
         bridge_data=bridge_data,
         horde_model_reference_manager=horde_model_reference_manager,
-        amd_gpu=amd_gpu,
-        directml=directml,
+        backend=backend,
     )
 
     logger.info("Worker has finished working.")
@@ -204,8 +207,30 @@ def init() -> None:
         default=None,
         help="Enable directml and specify device to use.",
     )
+    parser.add_argument(
+        "--xpu",
+        action="store_true",
+        default=False,
+        help="Enable Intel XPU support for Arc and other Intel GPUs.",
+    )
+    parser.add_argument(
+        "--oneapi-device-selector",
+        type=str,
+        default=None,
+        help="Restrict Intel XPU visibility using ONEAPI_DEVICE_SELECTOR, e.g. level_zero:gpu:0.",
+    )
 
     args = parser.parse_args()
+
+    try:
+        backend = HordeRuntimeBackend(
+            amd_gpu=args.amd,
+            directml=args.directml,
+            xpu=args.xpu,
+            oneapi_device_selector=args.oneapi_device_selector,
+        )
+    except ValueError as e:
+        parser.error(str(e))
 
     os.environ["HORDE_SDK_DISABLE_CUSTOM_SINKS"] = "1"
 
@@ -261,8 +286,7 @@ def init() -> None:
     main(
         multiprocessing.get_context("spawn"),
         args.load_config_from_env_vars,
-        amd_gpu=args.amd,
-        directml=args.directml,
+        backend=backend,
     )
 
 

--- a/horde_worker_regen/runtime_backend.py
+++ b/horde_worker_regen/runtime_backend.py
@@ -1,0 +1,111 @@
+"""Helpers for choosing and configuring the runtime backend used by the worker."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class HordeRuntimeBackend:
+    """Represents the GPU backend selected for the worker runtime."""
+
+    amd_gpu: bool = False
+    directml: int | None = None
+    xpu: bool = False
+    oneapi_device_selector: str | None = None
+
+    def __post_init__(self) -> None:
+        selected_backends = []
+
+        if self.amd_gpu:
+            selected_backends.append("--amd")
+        if self.directml is not None:
+            selected_backends.append("--directml")
+        if self.xpu:
+            selected_backends.append("--xpu")
+
+        if len(selected_backends) > 1:
+            raise ValueError(
+                "Backend flags are mutually exclusive. "
+                f"Choose only one of: {', '.join(selected_backends)}.",
+            )
+
+        if self.oneapi_device_selector is not None and not self.xpu:
+            raise ValueError("--oneapi-device-selector requires --xpu.")
+
+    @property
+    def name(self) -> str:
+        """Return a short name for the active backend."""
+        if self.directml is not None:
+            return "directml"
+        if self.xpu:
+            return "xpu"
+        if self.amd_gpu:
+            return "rocm"
+        return "cuda"
+
+    @property
+    def supports_gpu_safety(self) -> bool:
+        """Return whether GPU-backed safety is reliable on this backend."""
+        return self.directml is None and not self.xpu
+
+    def apply_environment(self) -> None:
+        """Apply any backend-specific environment variables for the current process."""
+        if self.oneapi_device_selector is not None:
+            os.environ["ONEAPI_DEVICE_SELECTOR"] = self.oneapi_device_selector
+
+    def append_comfyui_args(self, extra_comfyui_args: list[str]) -> None:
+        """Append backend-specific ComfyUI arguments in-place."""
+        if self.amd_gpu or self.xpu:
+            extra_comfyui_args.append("--use-pytorch-cross-attention")
+
+        if self.directml is not None:
+            extra_comfyui_args.append(f"--directml={self.directml}")
+
+
+def get_torch_device_infos(backend: HordeRuntimeBackend) -> list[tuple[str, int, int]]:
+    """Return the visible torch devices for the chosen backend."""
+    import torch
+
+    device_infos: list[tuple[str, int, int]] = []
+
+    if backend.directml is not None:
+        return device_infos
+
+    if backend.xpu:
+        if not hasattr(torch, "xpu") or not torch.xpu.is_available():
+            return device_infos
+
+        for index in range(torch.xpu.device_count()):
+            properties = torch.xpu.get_device_properties(index)
+            device_infos.append(
+                (
+                    getattr(properties, "name", torch.xpu.get_device_name(index)),
+                    index,
+                    properties.total_memory,
+                ),
+            )
+        return device_infos
+
+    for index in range(torch.cuda.device_count()):
+        properties = torch.cuda.get_device_properties(index)
+        device_infos.append((properties.name, index, properties.total_memory))
+
+    return device_infos
+
+
+def clear_torch_cache(backend: HordeRuntimeBackend) -> None:
+    """Clear the PyTorch cache for the active backend."""
+    import torch
+
+    if backend.directml is not None:
+        return
+
+    if backend.xpu:
+        if hasattr(torch, "xpu") and torch.xpu.is_available():
+            torch.xpu.empty_cache()
+        return
+
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()

--- a/runtime-xpu.sh
+++ b/runtime-xpu.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ ! -f "$SCRIPT_DIR/conda/envs/linux/bin/python" ]; then
+    "$SCRIPT_DIR/update-runtime-xpu.sh"
+fi
+"$SCRIPT_DIR/bin/micromamba" run -r "$SCRIPT_DIR/conda" -n linux "$@"

--- a/tests/test_runtime_backend.py
+++ b/tests/test_runtime_backend.py
@@ -1,0 +1,120 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "horde_worker_regen" / "runtime_backend.py"
+MODULE_SPEC = importlib.util.spec_from_file_location("runtime_backend", MODULE_PATH)
+assert MODULE_SPEC is not None
+assert MODULE_SPEC.loader is not None
+runtime_backend = importlib.util.module_from_spec(MODULE_SPEC)
+sys.modules[MODULE_SPEC.name] = runtime_backend
+MODULE_SPEC.loader.exec_module(runtime_backend)
+
+HordeRuntimeBackend = runtime_backend.HordeRuntimeBackend
+clear_torch_cache = runtime_backend.clear_torch_cache
+get_torch_device_infos = runtime_backend.get_torch_device_infos
+
+
+class RuntimeBackendTests(unittest.TestCase):
+    def test_conflicting_backends_raise(self) -> None:
+        with self.assertRaisesRegex(ValueError, "mutually exclusive"):
+            HordeRuntimeBackend(amd_gpu=True, xpu=True)
+
+    def test_oneapi_selector_requires_xpu(self) -> None:
+        with self.assertRaisesRegex(ValueError, "requires --xpu"):
+            HordeRuntimeBackend(oneapi_device_selector="level_zero:gpu:0")
+
+    def test_append_comfyui_args_for_xpu(self) -> None:
+        backend = HordeRuntimeBackend(xpu=True)
+        extra_args = ["--disable-smart-memory"]
+
+        backend.append_comfyui_args(extra_args)
+
+        self.assertEqual(extra_args, ["--disable-smart-memory", "--use-pytorch-cross-attention"])
+        self.assertFalse(backend.supports_gpu_safety)
+
+    def test_append_comfyui_args_for_directml(self) -> None:
+        backend = HordeRuntimeBackend(directml=0)
+        extra_args: list[str] = []
+
+        backend.append_comfyui_args(extra_args)
+
+        self.assertEqual(extra_args, ["--directml=0"])
+        self.assertFalse(backend.supports_gpu_safety)
+
+    def test_get_torch_device_infos_uses_xpu(self) -> None:
+        backend = HordeRuntimeBackend(xpu=True)
+        fake_torch = types.SimpleNamespace(
+            xpu=types.SimpleNamespace(
+                is_available=lambda: True,
+                device_count=lambda: 1,
+                get_device_properties=lambda index: types.SimpleNamespace(total_memory=16 * 1024**3),
+                get_device_name=lambda index: "Intel Arc A770",
+            ),
+            cuda=types.SimpleNamespace(device_count=lambda: 0),
+        )
+
+        with patch.dict("sys.modules", {"torch": fake_torch}):
+            infos = get_torch_device_infos(backend)
+
+        self.assertEqual(infos, [("Intel Arc A770", 0, 16 * 1024**3)])
+
+    def test_get_torch_device_infos_ignores_directml(self) -> None:
+        backend = HordeRuntimeBackend(directml=0)
+        fake_torch = types.SimpleNamespace(
+            cuda=types.SimpleNamespace(
+                device_count=lambda: 1,
+                get_device_properties=lambda index: types.SimpleNamespace(name="Unexpected CUDA", total_memory=1),
+            ),
+        )
+
+        with patch.dict("sys.modules", {"torch": fake_torch}):
+            infos = get_torch_device_infos(backend)
+
+        self.assertEqual(infos, [])
+
+    def test_clear_torch_cache_uses_xpu(self) -> None:
+        backend = HordeRuntimeBackend(xpu=True)
+        fake_xpu = types.SimpleNamespace(is_available=lambda: True, empty_cache=lambda: setattr(fake_xpu, "called", True))
+        fake_xpu.called = False
+        fake_torch = types.SimpleNamespace(xpu=fake_xpu, cuda=types.SimpleNamespace(is_available=lambda: False))
+
+        with patch.dict("sys.modules", {"torch": fake_torch}):
+            clear_torch_cache(backend)
+
+        self.assertTrue(fake_xpu.called)
+
+    def test_clear_torch_cache_uses_cuda(self) -> None:
+        backend = HordeRuntimeBackend()
+        fake_cuda = types.SimpleNamespace(
+            is_available=lambda: True,
+            empty_cache=lambda: setattr(fake_cuda, "called", True),
+        )
+        fake_cuda.called = False
+        fake_torch = types.SimpleNamespace(cuda=fake_cuda)
+
+        with patch.dict("sys.modules", {"torch": fake_torch}):
+            clear_torch_cache(backend)
+
+        self.assertTrue(fake_cuda.called)
+
+    def test_clear_torch_cache_ignores_directml(self) -> None:
+        backend = HordeRuntimeBackend(directml=0)
+        fake_cuda = types.SimpleNamespace(
+            is_available=lambda: True,
+            empty_cache=lambda: setattr(fake_cuda, "called", True),
+        )
+        fake_cuda.called = False
+        fake_torch = types.SimpleNamespace(cuda=fake_cuda)
+
+        with patch.dict("sys.modules", {"torch": fake_torch}):
+            clear_torch_cache(backend)
+
+        self.assertFalse(fake_cuda.called)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/update-runtime-xpu.sh
+++ b/update-runtime-xpu.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+hordelib=false
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    --hordelib)
+    hordelib=true
+    shift
+    ;;
+    *)
+    echo "Unknown option: $key"
+    exit 1
+    ;;
+esac
+done
+
+CONDA_ENVIRONMENT_FILE=environment.xpu.yaml
+PYTORCH_XPU_INDEX=https://download.pytorch.org/whl/xpu
+PYPI_INDEX=https://pypi.org/simple
+
+wget -qO- https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-linux-64.tar.bz2 | tar -xvj -C "${SCRIPT_DIR}"
+if [ ! -f "$SCRIPT_DIR/conda/envs/linux/bin/python" ]; then
+    ${SCRIPT_DIR}/bin/micromamba create --no-shortcuts -r "$SCRIPT_DIR/conda" -n linux -f ${CONDA_ENVIRONMENT_FILE} -y
+fi
+${SCRIPT_DIR}/bin/micromamba update --no-shortcuts -r "$SCRIPT_DIR/conda" -n linux -f ${CONDA_ENVIRONMENT_FILE} -y
+
+${SCRIPT_DIR}/bin/micromamba run -r "$SCRIPT_DIR/conda" -n linux python -s -m pip uninstall -y \
+    torch torchvision torchaudio triton xformers \
+    intel-extension-for-pytorch intel-cmplr-lib-rt intel-cmplr-lib-ur intel-cmplr-lic-rt intel-sycl-rt \
+    pytorch-triton-xpu tcmlib umf intel-pti \
+    pynvml nvidia-ml-py
+
+if [ "$hordelib" = true ]; then
+    ${SCRIPT_DIR}/bin/micromamba run -r "$SCRIPT_DIR/conda" -n linux python -s -m pip uninstall -y \
+        hordelib horde_engine horde_sdk horde_model_reference
+    ${SCRIPT_DIR}/bin/micromamba run -r "$SCRIPT_DIR/conda" -n linux python -s -m pip install \
+        horde_engine horde_model_reference \
+        --index-url "${PYTORCH_XPU_INDEX}" \
+        --extra-index-url "${PYPI_INDEX}"
+else
+    ${SCRIPT_DIR}/bin/micromamba run -r "$SCRIPT_DIR/conda" -n linux python -s -m pip install \
+        -r "$SCRIPT_DIR/requirements.txt" -U \
+        --index-url "${PYTORCH_XPU_INDEX}" \
+        --extra-index-url "${PYPI_INDEX}"
+fi
+
+echo "Intel XPU runtime installed."
+echo "Make sure the Intel GPU driver and Level Zero runtime are available on the host OS."


### PR DESCRIPTION
## Summary
- add a runtime backend abstraction with explicit XPU and oneAPI selector support
- add Linux XPU install/run scripts for Intel Arc
- route XPU safety to CPU and fix backend-specific torch cache and device handling
- document Intel Arc usage and add focused backend tests

## Validation
- python3 -m compileall horde_worker_regen download_models.py run_worker.py tests/test_runtime_backend.py
- python3 -m unittest tests.test_runtime_backend
- bash -n runtime-xpu.sh update-runtime-xpu.sh horde-bridge-xpu.sh