### PR TITLE
fix: correct RAM overhead calculation and remove redundant assignment

### DIFF
--- a/horde_worker_regen/process_management/process_manager.py
+++ b/horde_worker_regen/process_management/process_manager.py
@@ -1342,8 +1342,7 @@ class HordeWorkerProcessManager:
 
         self.total_ram_bytes = psutil.virtual_memory().total
 
-        self.target_ram_overhead_bytes = target_ram_overhead_bytes
-        self.target_ram_overhead_bytes = min(int(self.total_ram_bytes / 2), 9)
+        self.target_ram_overhead_bytes = min(int(self.total_ram_bytes / 2), target_ram_overhead_bytes)
 
         if any(model in VRAM_HEAVY_MODELS for model in self.bridge_data.image_models_to_load):
             # If the system ram is less than 24GB, then we're going to exit with an error


### PR DESCRIPTION
`HordeWorkerProcessManager.__init__` contained two issues in the initialization of `self.target_ram_overhead_bytes`:
1. A redundant assignment that was immediately overwritten on the next line
2. A missing unit multiplier, the value was capped at `9` (bytes) instead of the intended `target_ram_overhead_bytes` (9 GB by default), introduced as a regression in `31d86e6a`

This fix preserves the user-configured limit while ensuring it never exceeds 50% of total RAM.

**Notes:**
- `target_ram_bytes_used` (the property consuming this value) currently has no callers, so this is a non-breaking cleanup. The fix prevents incorrect near-zero headroom if memory enforcement is wired up in future.
- Pre-commit hooks passed. mypy skipped, project has pre-existing missing stubs for `psutil` unrelated to this change.