### PR TITLE
feat: summarize pending model downloads before fetching (fixes #400, #267)

### DIFF
--- a/README_advanced.md
+++ b/README_advanced.md
@@ -76,10 +76,10 @@ Now we compile the bridge library. We will point the Linux compiler directly to 
 git clone https://github.com/ROCm/librocdxg.git
 cd librocdxg
 
-# 2. Set the Windows SDK path 
+# 2. Set the Windows SDK path
 # IMPORTANT: Change "10.0.26100.0" below to match the folder version you found in Step 1!
 export win_sdk='/mnt/c/Program Files (x86)/Windows Kits/10/Include/10.0.26100.0/'
- 
+
 # 3. Configure the build environment
 mkdir -p build
 cd build

--- a/horde_worker_regen/download_models.py
+++ b/horde_worker_regen/download_models.py
@@ -1,5 +1,14 @@
 """Contains the code to download all models specified in the config file. Executable as a standalone script."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from hordelib.shared_model_manager import SharedModelManager
+
+    from horde_worker_regen.bridge_data.data_model import reGenBridgeData
+
 
 def download_all_models(
     *,
@@ -16,7 +25,7 @@ def download_all_models(
     from horde_model_reference.model_reference_manager import ModelReferenceManager
     from loguru import logger
 
-    from horde_worker_regen.bridge_data.load_config import BridgeDataLoader, reGenBridgeData
+    from horde_worker_regen.bridge_data.load_config import BridgeDataLoader
     from horde_worker_regen.consts import BRIDGE_CONFIG_FILENAME
 
     horde_model_reference_manager = ModelReferenceManager(
@@ -64,6 +73,8 @@ def download_all_models(
     from hordelib.shared_model_manager import SharedModelManager
 
     SharedModelManager.load_model_managers()
+
+    _log_pending_download_summary(bridge_data, SharedModelManager)
 
     if bridge_data.allow_lora:
         if SharedModelManager.manager.lora is None:
@@ -179,3 +190,66 @@ def download_all_models(
         exit(1)
     else:
         logger.success("Downloaded all compvis (Stable Diffusion) models.")
+
+
+def _log_pending_download_summary(
+    bridge_data: reGenBridgeData,
+    shared_model_manager: type[SharedModelManager],
+) -> None:
+    """Log how many model files are about to be downloaded, their total size, and whether they fit on disk.
+
+    Mirrors the download decisions made in `download_all_models` (see issues #400 and #267). LoRA downloads
+    are resolved dynamically by the LoRA model manager and are not included in the summary.
+    """
+    from loguru import logger
+
+    from horde_worker_regen.download_summary import (
+        PendingDownload,
+        collect_pending_downloads,
+        log_download_summary,
+        populate_download_sizes,
+    )
+
+    manager = shared_model_manager.manager
+    pending_by_category: dict[str, list[PendingDownload]] = {}
+
+    if bridge_data.allow_controlnet and manager.controlnet is not None:
+        controlnet_models = [
+            cn_model
+            for cn_model in manager.controlnet.model_reference
+            if bridge_data.allow_sdxl_controlnet or "sdxl" not in cn_model.lower()
+        ]
+        pending_by_category["ControlNet"] = collect_pending_downloads(manager.controlnet, controlnet_models)
+
+    if bridge_data.allow_sdxl_controlnet and manager.miscellaneous is not None:
+        pending_by_category["Miscellaneous"] = collect_pending_downloads(
+            manager.miscellaneous,
+            manager.miscellaneous.model_reference,
+        )
+
+    if bridge_data.allow_post_processing:
+        post_processing_managers = {
+            "GFPGAN": manager.gfpgan,
+            "ESRGAN": manager.esrgan,
+            "CodeFormer": manager.codeformer,
+        }
+        for category, post_processing_manager in post_processing_managers.items():
+            if post_processing_manager is not None:
+                pending_by_category[category] = collect_pending_downloads(
+                    post_processing_manager,
+                    post_processing_manager.model_reference,
+                )
+
+    if manager.compvis is not None:
+        pending_by_category["Stable Diffusion"] = collect_pending_downloads(
+            manager.compvis,
+            bridge_data.image_models_to_load,
+        )
+
+    all_pending = [pending for category_pending in pending_by_category.values() for pending in category_pending]
+    if all_pending:
+        logger.info(f"Checking the size of {len(all_pending)} model file(s) to download...")
+        populate_download_sizes(all_pending)
+
+    download_target_dir = manager.compvis.model_folder_path if manager.compvis is not None else None
+    log_download_summary(pending_by_category, download_target_dir=download_target_dir)

--- a/horde_worker_regen/download_summary.py
+++ b/horde_worker_regen/download_summary.py
@@ -61,8 +61,12 @@ class SupportsModelDownloads(Protocol):
         """Return True if the model is already downloaded and valid."""
         ...
 
-    def get_model_download(self, model_name: str) -> list[dict]:
-        """Return the download entries (with `file_url`) for the model."""
+    def get_model_download(self, model_name: str) -> list[dict] | dict:
+        """Return the download entries (with `file_url`) for the model.
+
+        Some hordelib releases annotate this as `dict` and others as `list[dict]`; at runtime it is a
+        list of download entries, but a single bare entry is tolerated here just in case.
+        """
         ...
 
 
@@ -76,10 +80,12 @@ def collect_pending_downloads(
         try:
             if model_manager.is_model_available(model_name):
                 continue
-            download_entries = model_manager.get_model_download(model_name)
+            raw_download_config = model_manager.get_model_download(model_name)
         except Exception as e:
             logger.debug(f"Could not inspect download info for model {model_name}: {e}")
             continue
+
+        download_entries = raw_download_config if isinstance(raw_download_config, list) else [raw_download_config]
 
         for download_entry in download_entries:
             file_url = download_entry.get("file_url")

--- a/horde_worker_regen/download_summary.py
+++ b/horde_worker_regen/download_summary.py
@@ -1,0 +1,162 @@
+"""Pre-download reporting: how many model files are about to be downloaded and how much space they need.
+
+Model reference records do not include file sizes, so sizes are resolved with HTTP HEAD requests
+(`Content-Length`) against the download URLs. Files whose size cannot be determined are still
+counted, but reported separately as "unknown size".
+"""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import Iterable
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+import requests
+from loguru import logger
+
+HEAD_REQUEST_TIMEOUT_SECONDS = 15
+MAX_PARALLEL_SIZE_CHECKS = 8
+
+DISK_SPACE_SAFETY_MARGIN = 1.05
+"""Warn when free disk space is below the total download size times this margin."""
+
+
+@dataclass
+class PendingDownload:
+    """A single model file which is about to be downloaded."""
+
+    model_name: str
+    file_url: str
+    size_bytes: int | None = None
+
+
+def format_bytes(num_bytes: float) -> str:
+    """Return a human readable size such as `1.24 GB`."""
+    for unit in ("B", "KB", "MB", "GB"):
+        if abs(num_bytes) < 1024:
+            return f"{num_bytes:.2f} {unit}" if unit != "B" else f"{int(num_bytes)} B"
+        num_bytes /= 1024
+    return f"{num_bytes:.2f} TB"
+
+
+def fetch_remote_file_size(file_url: str, *, timeout: float = HEAD_REQUEST_TIMEOUT_SECONDS) -> int | None:
+    """Return the size of a remote file in bytes using a HEAD request, or None if it cannot be determined."""
+    try:
+        response = requests.head(file_url, allow_redirects=True, timeout=timeout)
+        content_length = response.headers.get("Content-Length")
+        if content_length is not None and content_length.isdigit():
+            return int(content_length)
+    except requests.RequestException:
+        logger.debug(f"Could not determine remote file size for {file_url}")
+    return None
+
+
+class SupportsModelDownloads(Protocol):
+    """The parts of a hordelib model manager needed to inspect pending downloads."""
+
+    def is_model_available(self, model_name: str) -> bool:
+        """Return True if the model is already downloaded and valid."""
+        ...
+
+    def get_model_download(self, model_name: str) -> list[dict]:
+        """Return the download entries (with `file_url`) for the model."""
+        ...
+
+
+def collect_pending_downloads(
+    model_manager: SupportsModelDownloads,
+    model_names: Iterable[str],
+) -> list[PendingDownload]:
+    """Return the files which downloading the given models would fetch (models already on disk are skipped)."""
+    pending_downloads: list[PendingDownload] = []
+    for model_name in model_names:
+        try:
+            if model_manager.is_model_available(model_name):
+                continue
+            download_entries = model_manager.get_model_download(model_name)
+        except Exception as e:
+            logger.debug(f"Could not inspect download info for model {model_name}: {e}")
+            continue
+
+        for download_entry in download_entries:
+            file_url = download_entry.get("file_url")
+            if file_url:
+                pending_downloads.append(PendingDownload(model_name=model_name, file_url=file_url))
+
+    return pending_downloads
+
+
+def populate_download_sizes(pending_downloads: list[PendingDownload]) -> None:
+    """Fill in `size_bytes` for each pending download using parallel HEAD requests."""
+    if not pending_downloads:
+        return
+
+    with ThreadPoolExecutor(max_workers=MAX_PARALLEL_SIZE_CHECKS) as executor:
+        sizes = executor.map(lambda pending: fetch_remote_file_size(pending.file_url), pending_downloads)
+        for pending_download, size_bytes in zip(pending_downloads, sizes, strict=True):
+            pending_download.size_bytes = size_bytes
+
+
+def log_download_summary(
+    pending_by_category: dict[str, list[PendingDownload]],
+    *,
+    download_target_dir: str | Path | None = None,
+) -> None:
+    """Log a summary of the pending downloads (file counts and sizes, per category and overall).
+
+    If `download_target_dir` is given, also compare the total against the free disk space
+    and warn when it looks like the downloads will not fit (see issue #267).
+    """
+    all_pending = [pending for category_pending in pending_by_category.values() for pending in category_pending]
+
+    if not all_pending:
+        logger.info("All models are already downloaded; nothing new to fetch.")
+        return
+
+    total_known_bytes = 0
+    total_unknown_count = 0
+
+    logger.info(f"About to download {len(all_pending)} model file(s):")
+    for category, category_pending in pending_by_category.items():
+        if not category_pending:
+            continue
+
+        known_bytes = sum(pending.size_bytes for pending in category_pending if pending.size_bytes is not None)
+        unknown_count = sum(1 for pending in category_pending if pending.size_bytes is None)
+        total_known_bytes += known_bytes
+        total_unknown_count += unknown_count
+
+        size_note = format_bytes(known_bytes)
+        if unknown_count:
+            size_note += f" + {unknown_count} file(s) of unknown size"
+        logger.info(f"  {category}: {len(category_pending)} file(s), {size_note}")
+
+    total_note = format_bytes(total_known_bytes)
+    if total_unknown_count:
+        total_note += f" + {total_unknown_count} file(s) of unknown size"
+    logger.info(f"Total download size: {total_note}")
+
+    if download_target_dir is not None and total_known_bytes > 0:
+        _warn_if_low_disk_space(download_target_dir, total_known_bytes)
+
+
+def _warn_if_low_disk_space(download_target_dir: str | Path, total_download_bytes: int) -> None:
+    """Warn when the free space at the download location is unlikely to fit the pending downloads."""
+    try:
+        free_bytes = shutil.disk_usage(download_target_dir).free
+    except OSError as e:
+        logger.debug(f"Could not check free disk space for {download_target_dir}: {e}")
+        return
+
+    required_bytes = total_download_bytes * DISK_SPACE_SAFETY_MARGIN
+    if free_bytes < required_bytes:
+        logger.warning(
+            f"Low disk space: the pending downloads need about {format_bytes(total_download_bytes)} "
+            f"but only {format_bytes(free_bytes)} is free at {download_target_dir}. "
+            "The worker may fail or crash-loop if it runs out of disk space mid-download.",
+        )
+    else:
+        logger.info(f"Free disk space at {download_target_dir}: {format_bytes(free_bytes)} (sufficient)")

--- a/tests/test_download_summary.py
+++ b/tests/test_download_summary.py
@@ -1,0 +1,173 @@
+"""Tests for the pre-download summary (issues #400 and #267)."""
+
+from pathlib import Path
+
+import pytest
+
+from horde_worker_regen.download_summary import (
+    PendingDownload,
+    collect_pending_downloads,
+    format_bytes,
+    log_download_summary,
+    populate_download_sizes,
+)
+
+
+class FakeModelManager:
+    """Duck-typed stand-in for a hordelib model manager."""
+
+    def __init__(self, available_models: list[str], downloads: dict[str, list[dict]]) -> None:
+        """Initialise with the models considered on-disk and the download entries per model."""
+        self._available_models = available_models
+        self._downloads = downloads
+
+    def is_model_available(self, model_name: str) -> bool:
+        """Return True if the model was declared as already on disk."""
+        return model_name in self._available_models
+
+    def get_model_download(self, model_name: str) -> list[dict]:
+        """Return the declared download entries for the model."""
+        return self._downloads[model_name]
+
+
+def _capture_loguru_to_stdout() -> None:
+    from loguru import logger
+
+    logger.remove()
+    logger.add(lambda message: print(message, end=""), level="INFO", format="{message}")
+
+
+def test_format_bytes() -> None:
+    """Sizes are rendered with a sensible unit and two decimals."""
+    assert format_bytes(0) == "0 B"
+    assert format_bytes(512) == "512 B"
+    assert format_bytes(2048) == "2.00 KB"
+    assert format_bytes(5 * 1024**2) == "5.00 MB"
+    assert format_bytes(1.5 * 1024**3) == "1.50 GB"
+    assert format_bytes(2.25 * 1024**4) == "2.25 TB"
+
+
+def test_collect_pending_downloads_skips_available_models() -> None:
+    """Models already on disk are not counted as pending downloads."""
+    manager = FakeModelManager(
+        available_models=["model_on_disk"],
+        downloads={
+            "model_on_disk": [{"file_url": "https://example.com/on_disk.safetensors"}],
+            "model_missing": [{"file_url": "https://example.com/missing.safetensors"}],
+        },
+    )
+
+    pending = collect_pending_downloads(manager, ["model_on_disk", "model_missing"])
+
+    assert len(pending) == 1
+    assert pending[0].model_name == "model_missing"
+    assert pending[0].file_url == "https://example.com/missing.safetensors"
+
+
+def test_collect_pending_downloads_handles_multi_file_models_and_missing_urls() -> None:
+    """Every download entry with a URL is counted; entries without a URL are skipped."""
+    manager = FakeModelManager(
+        available_models=[],
+        downloads={
+            "multi_file_model": [
+                {"file_url": "https://example.com/part1.safetensors"},
+                {"file_url": "https://example.com/part2.yaml"},
+                {"file_url": None},
+                {},
+            ],
+        },
+    )
+
+    pending = collect_pending_downloads(manager, ["multi_file_model"])
+
+    assert [p.file_url for p in pending] == [
+        "https://example.com/part1.safetensors",
+        "https://example.com/part2.yaml",
+    ]
+
+
+def test_collect_pending_downloads_survives_manager_errors() -> None:
+    """A model manager raising for one model must not break the whole summary."""
+
+    class ExplodingManager:
+        def is_model_available(self, model_name: str) -> bool:
+            raise RuntimeError("boom")
+
+        def get_model_download(self, model_name: str) -> list[dict]:
+            return []
+
+    pending = collect_pending_downloads(ExplodingManager(), ["some_model"])
+
+    assert pending == []
+
+
+def test_populate_download_sizes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sizes resolved via HEAD requests are written back onto the pending downloads."""
+    sizes: dict[str, int | None] = {
+        "https://example.com/a.safetensors": 100,
+        "https://example.com/b.safetensors": None,
+    }
+    monkeypatch.setattr(
+        "horde_worker_regen.download_summary.fetch_remote_file_size",
+        lambda file_url, **kwargs: sizes[file_url],
+    )
+
+    pending = [
+        PendingDownload(model_name="a", file_url="https://example.com/a.safetensors"),
+        PendingDownload(model_name="b", file_url="https://example.com/b.safetensors"),
+    ]
+    populate_download_sizes(pending)
+
+    assert pending[0].size_bytes == 100
+    assert pending[1].size_bytes is None
+
+
+def test_log_download_summary_reports_totals(capsys: pytest.CaptureFixture[str]) -> None:
+    """The summary reports per-category and overall counts, sizes and unknown-size files."""
+    _capture_loguru_to_stdout()
+
+    pending_by_category = {
+        "Stable Diffusion": [
+            PendingDownload("model_a", "https://example.com/a", size_bytes=2 * 1024**3),
+            PendingDownload("model_b", "https://example.com/b", size_bytes=None),
+        ],
+        "ESRGAN": [],
+    }
+    log_download_summary(pending_by_category)
+
+    output = capsys.readouterr().out
+    assert "About to download 2 model file(s)" in output
+    assert "Stable Diffusion: 2 file(s), 2.00 GB + 1 file(s) of unknown size" in output
+    assert "Total download size: 2.00 GB + 1 file(s) of unknown size" in output
+
+
+def test_log_download_summary_nothing_to_download(capsys: pytest.CaptureFixture[str]) -> None:
+    """When everything is already on disk, the summary says so instead of listing categories."""
+    _capture_loguru_to_stdout()
+
+    log_download_summary({"Stable Diffusion": []})
+
+    output = capsys.readouterr().out
+    assert "All models are already downloaded" in output
+
+
+def test_log_download_summary_warns_on_low_disk_space(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A warning is logged when the pending downloads exceed the free disk space."""
+    import shutil as shutil_module
+
+    _capture_loguru_to_stdout()
+
+    fake_usage = shutil_module.disk_usage(tmp_path)._replace(free=1024)
+    monkeypatch.setattr("horde_worker_regen.download_summary.shutil.disk_usage", lambda path: fake_usage)
+
+    pending_by_category = {
+        "Stable Diffusion": [PendingDownload("model_a", "https://example.com/a", size_bytes=10 * 1024**3)],
+    }
+    log_download_summary(pending_by_category, download_target_dir=tmp_path)
+
+    output = capsys.readouterr().out
+    assert "Low disk space" in output

--- a/tests/test_download_summary.py
+++ b/tests/test_download_summary.py
@@ -16,7 +16,7 @@ from horde_worker_regen.download_summary import (
 class FakeModelManager:
     """Duck-typed stand-in for a hordelib model manager."""
 
-    def __init__(self, available_models: list[str], downloads: dict[str, list[dict]]) -> None:
+    def __init__(self, available_models: list[str], downloads: dict[str, list[dict] | dict]) -> None:
         """Initialise with the models considered on-disk and the download entries per model."""
         self._available_models = available_models
         self._downloads = downloads
@@ -25,7 +25,7 @@ class FakeModelManager:
         """Return True if the model was declared as already on disk."""
         return model_name in self._available_models
 
-    def get_model_download(self, model_name: str) -> list[dict]:
+    def get_model_download(self, model_name: str) -> list[dict] | dict:
         """Return the declared download entries for the model."""
         return self._downloads[model_name]
 
@@ -84,6 +84,20 @@ def test_collect_pending_downloads_handles_multi_file_models_and_missing_urls() 
         "https://example.com/part1.safetensors",
         "https://example.com/part2.yaml",
     ]
+
+
+def test_collect_pending_downloads_accepts_a_bare_dict_entry() -> None:
+    """Older hordelib releases may hand back a single dict instead of a list of entries."""
+    manager = FakeModelManager(
+        available_models=[],
+        downloads={
+            "legacy_model": {"file_url": "https://example.com/legacy.safetensors"},
+        },
+    )
+
+    pending = collect_pending_downloads(manager, ["legacy_model"])
+
+    assert [p.file_url for p in pending] == ["https://example.com/legacy.safetensors"]
 
 
 def test_collect_pending_downloads_survives_manager_errors() -> None:


### PR DESCRIPTION
## What this does

Closes #400
Closes #267

Before any model download starts, `download_models.py` now logs:

- how many model files are about to be downloaded, per model category (Stable Diffusion, ControlNet, GFPGAN, ESRGAN, CodeFormer, Miscellaneous) and overall
- their total size in human-readable units
- a **low disk space warning** when the pending downloads are unlikely to fit at the model folder location (#267)

Example output:

```
INFO | Checking the size of 12 model file(s) to download...
INFO | About to download 12 model file(s):
INFO |   ControlNet: 6 file(s), 8.41 GB
INFO |   ESRGAN: 2 file(s), 130.42 MB
INFO |   Stable Diffusion: 4 file(s), 12.87 GB + 1 file(s) of unknown size
INFO | Total download size: 21.41 GB + 1 file(s) of unknown size
WARNING | Low disk space: the pending downloads need about 21.41 GB but only 14.20 GB is free at /workers/models. The worker may fail or crash-loop if it runs out of disk space mid-download.
```

## How

The model reference doesn't include file sizes, so sizes are resolved with **parallel HTTP HEAD requests** (`Content-Length`, follows redirects, 8 workers, 15s timeout) against the download URLs. Anything that can't be resolved (network error, missing header) is still counted but reported as "unknown size" — the summary never blocks or fails the download flow; every failure path degrades to a debug log.

- New module `horde_worker_regen/download_summary.py`: pure, unit-testable helpers (duck-typed via a `Protocol`, no hordelib import needed for tests)
- `download_models.py`: `_log_pending_download_summary()` mirrors the existing download decisions (`allow_controlnet`/`allow_sdxl_controlnet`/`allow_post_processing`/`image_models_to_load`) and runs right after `SharedModelManager.load_model_managers()`
- LoRA downloads are resolved dynamically by the LoRA manager and are not included in the summary (noted in the docstring)

## Testing

- 8 new unit tests in `tests/test_download_summary.py` (no GPU/hordelib needed) — all pass
- ruff, black and mypy pass on the changed files
- Smoke-tested `fetch_remote_file_size()` against a real model reference URL (HuggingFace redirect chain): correctly reports 4.86 GB for `model_2_1.ckpt`

## Possible follow-up

Fine-grained aggregate progress bars in GB (the second half of #400) would need progress hooks in hordelib's `download_file` — happy to tackle that next if there's interest.

---

*Co-written by a human (@oliver0006) and Claude AI (Fable 5) working together.*
