### PR TITLE
feat: allow setting config file location by env var (fixes #17)

### DIFF
--- a/README_advanced.md
+++ b/README_advanced.md
@@ -76,10 +76,10 @@ Now we compile the bridge library. We will point the Linux compiler directly to 
 git clone https://github.com/ROCm/librocdxg.git
 cd librocdxg
 
-# 2. Set the Windows SDK path 
+# 2. Set the Windows SDK path
 # IMPORTANT: Change "10.0.26100.0" below to match the folder version you found in Step 1!
 export win_sdk='/mnt/c/Program Files (x86)/Windows Kits/10/Include/10.0.26100.0/'
- 
+
 # 3. Configure the build environment
 mkdir -p build
 cd build

--- a/README_advanced.md
+++ b/README_advanced.md
@@ -162,6 +162,7 @@ HSA Agents
 
 ### Run worker
 - Set your config now, copying `bridgeData_template.yaml` to `bridgeData.yaml`, being sure to set an API key and worker name at a minimum
+  - Optionally, set the `AIWORKER_BRIDGE_DATA_LOCATION` environment variable to load the config from a different path (useful for containers or running multiple workers from one checkout)
 - `python download_models.py` (**critical - must be run first every time**)
 - `python run_worker.py` (to start working)
 

--- a/convert_config_to_env.py
+++ b/convert_config_to_env.py
@@ -14,9 +14,13 @@ import argparse
 from horde_model_reference.model_reference_manager import ModelReferenceManager
 
 from horde_worker_regen.bridge_data.load_config import BridgeDataLoader, ConfigFormat
+from horde_worker_regen.consts import BRIDGE_CONFIG_FILENAME
 
 
-def convert_config_to_env(config_filename: str = "bridgeData.yaml", dot_env_filename: str = "bridgeData.env") -> None:
+def convert_config_to_env(
+    config_filename: str = BRIDGE_CONFIG_FILENAME,
+    dot_env_filename: str = "bridgeData.env",
+) -> None:
     """Convert the config file to an env file (suitable for use in a container or similar)."""
     bridge_data_loader = BridgeDataLoader()
     horde_model_reference_manager = ModelReferenceManager(
@@ -51,7 +55,7 @@ if __name__ == "__main__":
         "-f",
         type=str,
         help="The file to convert",
-        default="bridgeData.yaml",
+        default=BRIDGE_CONFIG_FILENAME,
     )
     args = parser.parse_args()
 

--- a/horde_worker_regen/consts.py
+++ b/horde_worker_regen/consts.py
@@ -1,6 +1,11 @@
 """Constants for the reGen bridge."""
 
-BRIDGE_CONFIG_FILENAME = "bridgeData.yaml"
+import os
+
+DEFAULT_BRIDGE_CONFIG_FILENAME = "bridgeData.yaml"
+
+BRIDGE_CONFIG_FILENAME = os.environ.get("AIWORKER_BRIDGE_DATA_LOCATION", DEFAULT_BRIDGE_CONFIG_FILENAME)
+"""The bridge config file location. Overridable with the `AIWORKER_BRIDGE_DATA_LOCATION` env var."""
 
 VERSION_META_REMOTE_URL = (
     "https://raw.githubusercontent.com/Haidra-Org/horde-worker-reGen/main/horde_worker_regen/_version_meta.json"

--- a/horde_worker_regen/load_env_vars.py
+++ b/horde_worker_regen/load_env_vars.py
@@ -12,8 +12,10 @@ load_dotenv()
 
 def load_env_vars_from_config() -> None:  # FIXME: there is a dynamic way to do this
     """Load the environment variables from the config file."""
+    from horde_worker_regen.consts import BRIDGE_CONFIG_FILENAME
+
     yaml = YAML()
-    config_file = "bridgeData.yaml"
+    config_file = BRIDGE_CONFIG_FILENAME
     template_file = "bridgeData_template.yaml"
 
     if not pathlib.Path(config_file).exists():

--- a/model-stats.py
+++ b/model-stats.py
@@ -14,6 +14,8 @@ import requests
 import yaml
 from tqdm import tqdm
 
+from horde_worker_regen.consts import BRIDGE_CONFIG_FILENAME
+
 # Location of stable horde worker bridge log
 LOG_FILE = "logs/bridge*.log"
 
@@ -71,7 +73,7 @@ class LogStats:
     def parse_log(self) -> None:
         self.used_models = {}
         # Grab any statically loaded models
-        with open("bridgeData.yaml", encoding="utf-8", errors="ignore") as configfile:
+        with open(BRIDGE_CONFIG_FILENAME, encoding="utf-8", errors="ignore") as configfile:
             config = yaml.safe_load(configfile)
         self.unused_models = config["models_to_load"]
         # Models to exclude

--- a/tests/test_bridge_config_location.py
+++ b/tests/test_bridge_config_location.py
@@ -1,0 +1,35 @@
+"""Tests for the bridge config file location override (issue #17)."""
+
+import importlib
+from collections.abc import Generator
+
+import pytest
+
+import horde_worker_regen.consts
+
+
+@pytest.fixture(autouse=True)
+def _restore_consts_module() -> Generator[None, None, None]:
+    """Reload the consts module after each test so the reloads here don't leak into other tests."""
+    yield
+    importlib.reload(horde_worker_regen.consts)
+
+
+def test_bridge_config_filename_defaults_to_bridgedata_yaml(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without the env var, the config location is the historical `bridgeData.yaml`."""
+    monkeypatch.delenv("AIWORKER_BRIDGE_DATA_LOCATION", raising=False)
+
+    consts = importlib.reload(horde_worker_regen.consts)
+
+    assert consts.BRIDGE_CONFIG_FILENAME == "bridgeData.yaml"
+    assert consts.DEFAULT_BRIDGE_CONFIG_FILENAME == "bridgeData.yaml"
+
+
+def test_bridge_config_filename_overridden_by_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`AIWORKER_BRIDGE_DATA_LOCATION` overrides the config location, including full paths."""
+    monkeypatch.setenv("AIWORKER_BRIDGE_DATA_LOCATION", "/configs/worker1/bridgeData.yaml")
+
+    consts = importlib.reload(horde_worker_regen.consts)
+
+    assert consts.BRIDGE_CONFIG_FILENAME == "/configs/worker1/bridgeData.yaml"
+    assert consts.DEFAULT_BRIDGE_CONFIG_FILENAME == "bridgeData.yaml"


### PR DESCRIPTION
## What this does

Closes #17

The bridge config file location can now be set with the **`AIWORKER_BRIDGE_DATA_LOCATION`** environment variable:

```bash
AIWORKER_BRIDGE_DATA_LOCATION=/configs/worker1/bridgeData.yaml python run_worker.py
```

When the variable is not set, the location is the historical `bridgeData.yaml` in the working directory — **zero behavior change for existing setups** (including the Docker entrypoint).

Useful for containers mounting the config elsewhere, centralized config directories, or running multiple workers with different configs from one checkout.

## How

- `consts.py`: `BRIDGE_CONFIG_FILENAME` is now resolved from the env var, with `DEFAULT_BRIDGE_CONFIG_FILENAME` keeping the historical name. Every call site — `run_worker.py`, `download_models.py`, and the hot-reload mtime watcher in `process_manager.py` — already imports this constant, so they all pick up the override automatically with no further changes.
- Also swaps the three places that hardcoded `"bridgeData.yaml"` instead of using the constant (`load_env_vars.py`, `convert_config_to_env.py`, `model-stats.py`), fixing that inconsistency.
- One doc line in `README_advanced.md`.

The env var name follows the existing `AIWORKER_*` convention (`AIWORKER_CACHE_HOME`, `AIWORKER_DREAMER_WORKER_NAME`, …) — happy to rename if you'd prefer something else.

## Testing

- 2 new unit tests (`tests/test_bridge_config_location.py`): default behavior and override, with a fixture restoring the module state after each test
- ruff, black and mypy pass on the changed files
- Functional check: `AIWORKER_BRIDGE_DATA_LOCATION=/tmp/autre/config.yaml` → constant resolves to the override; unset → `bridgeData.yaml`

---

*Co-written by a human (@oliver0006) and Claude AI (Fable 5) working together — same duo as #447.*
